### PR TITLE
Improve autocompletion suggestions using the "named types" scope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 .DS_Store
 test.lua
 .luacompleterc
+.tags1
+.tags
+TODO*
 node_modules

--- a/lib/analysis.js
+++ b/lib/analysis.js
@@ -4,34 +4,34 @@
  * The type analysis sweep
  */
 
+import config from './config'
 import {
   tableNew, unknownNew,
   tableSet, tableGet, tableSetMetatable, tableGetMetatable,
-  tableSearch,
-  tableInvalidateDiffs, tableFreeze, tableDiffShallow, tableDiff, tableApplyDiff
+  tableSearch, tableInvalidateDiffs, tableFreeze,
+  tableDiffShallow, tableDiff, tableApplyDiff
 } from './typedefs'
 import { nodeGetType, nodeGetReturnTypes } from './resolve'
-import extractTypes from './extraction'
+import { extractTypes, CompletionStrategy } from './extraction'
 import formatResults from './format'
 import luaparse from 'luaparse'
 import ModuleCache from './module-cache'
-import config from './config'
 
-//A class constructed around the luaparse package. The _on methods are
-//used as callbacks for the luaparse package.
+// A class constructed around the luaparse package. The _on methods are
+// used as callbacks for the luaparse package.
 // https://github.com/oxyc/luaparse for more info
 export default class Analysis {
-  constructor (options, query) {
+  constructor (options, query, namedTypes) {
     this.query = query
     this.queryBase = null
 
-    //Holds all the defined identifiers in the current lua file. Its metatable
-    //is the global named type list.
+    // Holds all the defined identifiers in the current lua file. Its metatable
+    // is the global named type list.
     this.queryType = null
 
     this.chunk = null
     if (query && query.dot !== ':' && query.dot !== '.') {
-      query.dot = null //Initialize query.dot if it was not already created
+      query.dot = null
     }
 
     const globalScope = options.global
@@ -41,14 +41,17 @@ export default class Analysis {
     }
     tableFreeze(globalScope)
 
+    if (config.suggestUsedMembers === CompletionStrategy.TYPE_ASSUMPTION) {
+      this.namedTypes = namedTypes
+    }
     this.currentScope = globalScope
     this.globalScope = globalScope
     this.options = options
-    options.moduleCache = options.moduleCache || new ModuleCache(options)
-
     this.iteration = []
     this.requires = new Set()
     this.requireCache = {}
+
+    options.moduleCache = options.moduleCache || new ModuleCache(options)
 
     luaparse.parse({
       wait: true,
@@ -65,7 +68,7 @@ export default class Analysis {
 
   _onCreateNode = (node) => {
     this.iteration.push(node)
-    node.scope = this.currentScope //Reflection?
+    node.scope = this.currentScope
     node.globalScope = this.globalScope
     node.options = this.options
 
@@ -161,7 +164,13 @@ export default class Analysis {
       tableInvalidateDiffs()
       tableApplyDiff(mainDiff)
     }
-    this.iteration.forEach(extractTypes)
+    if (this.namedTypes) {
+      this.iteration.forEach((element) => {
+        extractTypes(element, this.namedTypes)
+      })
+    } else {
+      this.iteration.forEach(extractTypes)
+    }
 
     // Due to the stateful nature of tableDiffCount, we need to sample data
     // quickly before we return to the run loop and let another Analysis take
@@ -197,10 +206,6 @@ export default class Analysis {
       if (!queryType) {
         console.log('query has no type', this.query.prefix)
         return []
-      //v v if we are indexing
-      } else if (this.queryBase) {
-        let queryBaseType = this.queryBase.scope.fields[this.queryBase.name]
-        console.log(queryBaseType, ' ; ', this.queryBase)
       }
 
       let results = tableSearch(queryType, this.query.prefix)
@@ -211,10 +216,5 @@ export default class Analysis {
       results.sort((a, b) => a.key.localeCompare(b.key))
       return formatResults(results, trimSelf)
     })
-  }
-
-  //Finds an autocompletion suggestion in the whole cache, ignoring type
-  findInCache = function (prefix) {
-
   }
 }

--- a/lib/analysis.js
+++ b/lib/analysis.js
@@ -17,14 +17,21 @@ import luaparse from 'luaparse'
 import ModuleCache from './module-cache'
 import config from './config'
 
+//A class constructed around the luaparse package. The _on methods are
+//used as callbacks for the luaparse package.
+// https://github.com/oxyc/luaparse for more info
 export default class Analysis {
   constructor (options, query) {
     this.query = query
     this.queryBase = null
+
+    //Holds all the defined identifiers in the current lua file. Its metatable
+    //is the global named type list.
     this.queryType = null
+
     this.chunk = null
     if (query && query.dot !== ':' && query.dot !== '.') {
-      query.dot = null
+      query.dot = null //Initialize query.dot if it was not already created
     }
 
     const globalScope = options.global
@@ -46,19 +53,19 @@ export default class Analysis {
     luaparse.parse({
       wait: true,
       comments: false,
-      ranges: true,
       scope: true,
-      luaVersion: options.luaVersion || config.luaVersion || '5.2',
+      ranges: true,
       onCreateNode: this._onCreateNode,
       onCreateScope: this._onCreateScope,
       onDestroyScope: this._onDestroyScope,
-      onScopeIdentifierName: this._onScopeIdentifierName
+      onScopeIdentifierName: this._onScopeIdentifierName,
+      luaVersion: options.luaVersion || config.luaVersion || '5.2'
     })
   }
 
   _onCreateNode = (node) => {
     this.iteration.push(node)
-    node.scope = this.currentScope
+    node.scope = this.currentScope //Reflection?
     node.globalScope = this.globalScope
     node.options = this.options
 
@@ -187,7 +194,14 @@ export default class Analysis {
         queryType = nodeGetType(this.queryBase)
       }
 
-      if (!queryType) { return [] }
+      if (!queryType) {
+        console.log('query has no type', this.query.prefix)
+        return []
+      //v v if we are indexing
+      } else if (this.queryBase) {
+        let queryBaseType = this.queryBase.scope.fields[this.queryBase.name]
+        console.log(queryBaseType, ' ; ', this.queryBase)
+      }
 
       let results = tableSearch(queryType, this.query.prefix)
       const trimSelf = this.query.dot === ':'
@@ -197,5 +211,10 @@ export default class Analysis {
       results.sort((a, b) => a.key.localeCompare(b.key))
       return formatResults(results, trimSelf)
     })
+  }
+
+  //Finds an autocompletion suggestion in the whole cache, ignoring type
+  findInCache = function (prefix) {
+
   }
 }

--- a/lib/analysis.js
+++ b/lib/analysis.js
@@ -203,10 +203,7 @@ export default class Analysis {
         queryType = nodeGetType(this.queryBase)
       }
 
-      if (!queryType) {
-        console.log('query has no type', this.query.prefix)
-        return []
-      }
+      if (!queryType) { return [] }
 
       let results = tableSearch(queryType, this.query.prefix)
       const trimSelf = this.query.dot === ':'

--- a/lib/extraction.js
+++ b/lib/extraction.js
@@ -14,8 +14,6 @@ import {
 } from './typedefs'
 
 // Describe the algorithm to use to suggest members of unknown tables
-// NOTE: It seems that having to import into index.js this structure adds
-// a lot of time to the startup of Atom
 export const CompletionStrategy = {
   VANILLA: 0,
   ALREADY_USED_ONLY: 1,

--- a/lib/extraction.js
+++ b/lib/extraction.js
@@ -13,6 +13,13 @@ import {
   mergeTypeKnowledge, tableApplyDiff
 } from './typedefs'
 
+//Describe the algorithm to use to suggest members of unknown tables
+export const CompletionStrategy = {
+ VANILLA : 0,
+ ALREADY_USED_ONLY: 1,
+ TYPE_ASSUMPTION: 2
+}
+
 const __metatable__ = Symbol()
 const discoveredType = (table, key, newType, allowOverwrite) => {
   if (!table || table.type !== 'table') { return }
@@ -61,7 +68,7 @@ export default function extractTypes (node) {
   }
   // An indexing expression comes with the assumption that the base is a table
   // Similarilly, a function call usually means that function exists
-  if (config.suggestUsedMembers) {
+  if (config.suggestUsedMembers === CompletionStrategy.ALREADY_USED_ONLY) {
     const isFunctionCall = type === 'CallExpression'
     const isMember = type === 'MemberExpression' || type === 'IndexExpression'
     if (isFunctionCall || isMember) {
@@ -77,7 +84,10 @@ export default function extractTypes (node) {
         discoveredType(lvalue.table, lvalue.key, unknownNew())
       }
     }
+  } else if (config.suggestUsedMembers === CompletionStrategy.TYPE_ASSUMPTION) {
+
   }
+
   if (type === 'CallExpression' && node.base.type === 'Identifier' && node.base.name === 'setmetatable') {
     if (node.arguments.length < 2) { return }
     const tableType = nodeGetType(node.arguments[0])

--- a/lib/extraction.js
+++ b/lib/extraction.js
@@ -141,15 +141,18 @@ function getTypeWithMember (scopeNamedTypes, member, previousType) {
   let mostPromisingTypeLength = Infinity
   for (let namedTypeName in scopeNamedTypes) {
     if (scopeNamedTypes.hasOwnProperty(namedTypeName)) {
-      let namedTypeMembers = scopeNamedTypes[namedTypeName]
-      let currentTypeLength = Object.keys(namedTypeMembers.fields).length
+      let namedTypeContent = scopeNamedTypes[namedTypeName]
+      if (namedTypeContent.type !== 'table') {
+        continue // If the namedType is not a table, it doesn't interest us
+      }
+      let currentTypeLength = Object.keys(namedTypeContent.fields).length || 0
 
       if (currentTypeLength > previousTypeLength &&
         currentTypeLength < mostPromisingTypeLength &&
-        exactTableSearch(namedTypeMembers, member)
+        exactTableSearch(namedTypeContent, member)
       ) {
         mostPromisingTypeLength = currentTypeLength
-        candidate = {members: namedTypeMembers.fields, name: namedTypeName}
+        candidate = {members: namedTypeContent.fields, name: namedTypeName}
       }
     }
   }

--- a/lib/extraction.js
+++ b/lib/extraction.js
@@ -9,38 +9,45 @@ import config from './config'
 import { getLValue, nodeGetType } from './resolve'
 import {
   tableSet, tableSetMetatable, tableGet, tableGetMetatable,
-  unknownNew, tableNew, functionNew,
+  unknownNew, tableNew, functionNew, exactTableSearch,
   mergeTypeKnowledge, tableApplyDiff
 } from './typedefs'
 
-//Describe the algorithm to use to suggest members of unknown tables
+// Describe the algorithm to use to suggest members of unknown tables
+// NOTE: It seems that having to import into index.js this structure adds
+// a lot of time to the startup of Atom
 export const CompletionStrategy = {
- VANILLA : 0,
- ALREADY_USED_ONLY: 1,
- TYPE_ASSUMPTION: 2
+  VANILLA: 0,
+  ALREADY_USED_ONLY: 1,
+  TYPE_ASSUMPTION: 2
 }
 
 const __metatable__ = Symbol()
 const discoveredType = (table, key, newType, allowOverwrite) => {
-  if (!table || table.type !== 'table') { return }
+  if (!table || table.type !== 'table') {
+    return
+  } else {
+    const isMeta = key === __metatable__
+    const oldType = isMeta ? tableGetMetatable(table) : tableGet(table, key)
 
-  const isMeta = key === __metatable__
-  const oldType = isMeta ? tableGetMetatable(table) : tableGet(table, key)
-
-  const mergedType = mergeTypeKnowledge(oldType, newType)
-  if (mergedType !== oldType) {
-    if (isMeta) {
-      tableSetMetatable(table, mergedType)
-    } else {
-      tableSet(table, key, mergedType)
+    const mergedType = mergeTypeKnowledge(oldType, newType)
+    if (mergedType !== oldType) {
+      if (isMeta) {
+        tableSetMetatable(table, mergedType)
+      } else {
+        tableSet(table, key, mergedType)
+      }
     }
   }
 }
 
-export default function extractTypes (node) {
+// Interpolates identifier types (ie: their table members) based on the syntaxic
+// tree of the file.
+// namedTypes is specified if you want the extraction process to provide
+// types on unknown type variables. It is the namedTypes of the option object
+export default function extractTypes (node, namedTypes) {
   if (!node || node.isPlaceholder) { return }
   const type = node.type
-
   if (node.requireCache) {
     const entry = node.requireCache[node.requireValue]
     if (!entry) { return }
@@ -68,31 +75,59 @@ export default function extractTypes (node) {
   }
   // An indexing expression comes with the assumption that the base is a table
   // Similarilly, a function call usually means that function exists
-  if (config.suggestUsedMembers === CompletionStrategy.ALREADY_USED_ONLY) {
-    const isFunctionCall = type === 'CallExpression'
-    const isMember = type === 'MemberExpression' || type === 'IndexExpression'
-    if (isFunctionCall || isMember) {
-      const lvalue = getLValue(node.base)
-      if (lvalue) {
-        const newType = isFunctionCall ? functionNew() : tableNew()
-        discoveredType(lvalue.table, lvalue.key, newType)
+  const isMember = type === 'MemberExpression' || type === 'IndexExpression'
+  const isFunctionCall = type === 'CallExpression'
+  const scopeValues = getLValue(node.base) // holds identifiers defined within the file
+  if (scopeValues) {
+    if (config.suggestUsedMembers === CompletionStrategy.ALREADY_USED_ONLY) {
+      if (isFunctionCall) {
+        discoveredType(scopeValues.table, scopeValues.key, functionNew())
+      } else if (isMember) {
+        discoveredType(scopeValues.table, scopeValues.key, tableNew())
+        const lvalue = getLValue(node)
+        if (lvalue) {
+          discoveredType(lvalue.table, lvalue.key, unknownNew())
+        }
+      }
+    } else if (namedTypes) { // This is true only if CompletionStrategy.TYPE_ASSUMPTION
+      if (isFunctionCall) {
+        discoveredType(scopeValues.table, scopeValues.key, functionNew())
+      } else if (isMember) {
+        const wasUnknown = getLValue(node).table.type === 'unknown'
+        discoveredType(scopeValues.table, scopeValues.key, tableNew())
+        if (wasUnknown) {
+          const lvalue = getLValue(node)
+          var likelyType = getTypeWithMember(namedTypes, lvalue.key)
+          Object.assign(
+            lvalue.table.fields, lvalue.table.fields, likelyType.fields)
+        }
       }
     }
-    if (isMember) {
-      const lvalue = getLValue(node)
-      if (lvalue) {
-        discoveredType(lvalue.table, lvalue.key, unknownNew())
-      }
-    }
-  } else if (config.suggestUsedMembers === CompletionStrategy.TYPE_ASSUMPTION) {
-
   }
 
-  if (type === 'CallExpression' && node.base.type === 'Identifier' && node.base.name === 'setmetatable') {
+  if (type === 'CallExpression' &&
+    node.base.type === 'Identifier' &&
+    node.base.name === 'setmetatable'
+  ) {
     if (node.arguments.length < 2) { return }
     const tableType = nodeGetType(node.arguments[0])
     if (!tableType || tableType.type !== 'table') { return }
     const metatableType = nodeGetType(node.arguments[1])
     discoveredType(tableType, __metatable__, metatableType)
   }
+}
+
+// Returns the type in scope which has member with the given member
+function getTypeWithMember (scopeNamedTypes, member) {
+  // let candidate = null // the namedType containing memberPrefix which is the
+  for (let namedTypeName in scopeNamedTypes) {
+    if (scopeNamedTypes.hasOwnProperty(namedTypeName)) {
+      let namedTypeMembers = scopeNamedTypes[namedTypeName]
+      if (exactTableSearch(namedTypeMembers, member)) {
+        return namedTypeMembers
+      }
+    }
+  }
+  // TODO: Apply an heuristic over all discovered types to
+  // provide more pertinent results
 }

--- a/lib/extraction.js
+++ b/lib/extraction.js
@@ -92,22 +92,39 @@ export function extractTypes (node, namedTypes) {
         discoveredType(scopeValues.table, scopeValues.key, functionNew())
       } else if (isMember) {
         let wasUnknownOrInferred = false
-        let previousTypeName = null
-        ; {
+        let previousTypeName
+        let nilTableAccess = false
+        try {
+          // Retrive previously inferred type from the node
+          // Determine if the table needs its type to be deduced
           const nodeTable = getLValue(node).table
           wasUnknownOrInferred = (
             nodeTable.type === 'unknown' ||
             nodeTable.inferredTypeName !== undefined
           )
           previousTypeName = nodeTable.inferredTypeName
+        } catch (error) {
+          // TypeError means user is trying to do an illegal nil value access
+          // Which is an error, but we let them do what they want.
+          if (error.name !== 'TypeError') {
+            throw error
+          } else {
+            nilTableAccess = true
+            wasUnknownOrInferred = false
+          }
         }
-        discoveredType(scopeValues.table, scopeValues.key, tableNew())
+        if (!nilTableAccess) {
+          discoveredType(scopeValues.table, scopeValues.key, tableNew())
+        }
+        // We handle unknown or inferred types with the deduction algorithm
         if (wasUnknownOrInferred) {
           let lvalue = getLValue(node)
           const likelyType = getTypeWithMember(namedTypes, lvalue.key, previousTypeName)
           if (likelyType) {
-            Object.assign(lvalue.table.fields, lvalue.table.fields, likelyType.members)
+            Object.assign(lvalue.table.fields, lvalue.table.fields, likelyType.fields)
             lvalue.table.inferredTypeName = likelyType.name
+            lvalue.table.description = likelyType.description
+            lvalue.table.link = likelyType.link
           }
         }
       }
@@ -128,10 +145,10 @@ export function extractTypes (node, namedTypes) {
 
 // Returns the type in scope which has member with the given member
 // previousType is an optional hint as to what type the identifier was judged as
-// The returned object is of the form
-// {members:(namedType members), name:(name of the namedType)}
+// The returned object has the same attributes as a namedType, with an extra
+// name: type name field.
 // It searches for the namedType with the lowest number of fields yet still
-// striclty greater than the previousType's fields count.
+// equal or greater than the previousType's fields count.
 function getTypeWithMember (scopeNamedTypes, member, previousType) {
   let candidate = {}
   const previousTypeLength = (previousType
@@ -147,12 +164,13 @@ function getTypeWithMember (scopeNamedTypes, member, previousType) {
       }
       let currentTypeLength = Object.keys(namedTypeContent.fields).length || 0
 
-      if (currentTypeLength > previousTypeLength &&
+      if (currentTypeLength >= previousTypeLength &&
         currentTypeLength < mostPromisingTypeLength &&
         exactTableSearch(namedTypeContent, member)
       ) {
         mostPromisingTypeLength = currentTypeLength
-        candidate = {members: namedTypeContent.fields, name: namedTypeName}
+        candidate = namedTypeContent
+        candidate.name = namedTypeName
       }
     }
   }

--- a/lib/extraction.js
+++ b/lib/extraction.js
@@ -45,7 +45,7 @@ const discoveredType = (table, key, newType, allowOverwrite) => {
 // tree of the file.
 // namedTypes is specified if you want the extraction process to provide
 // types on unknown type variables. It is the namedTypes of the option object
-export default function extractTypes (node, namedTypes) {
+export function extractTypes (node, namedTypes) {
   if (!node || node.isPlaceholder) { return }
   const type = node.type
   if (node.requireCache) {
@@ -93,13 +93,24 @@ export default function extractTypes (node, namedTypes) {
       if (isFunctionCall) {
         discoveredType(scopeValues.table, scopeValues.key, functionNew())
       } else if (isMember) {
-        const wasUnknown = getLValue(node).table.type === 'unknown'
+        let wasUnknownOrInferred = false
+        let previousTypeName = null
+        ; {
+          const nodeTable = getLValue(node).table
+          wasUnknownOrInferred = (
+            nodeTable.type === 'unknown' ||
+            nodeTable.inferredTypeName !== undefined
+          )
+          previousTypeName = nodeTable.inferredTypeName
+        }
         discoveredType(scopeValues.table, scopeValues.key, tableNew())
-        if (wasUnknown) {
-          const lvalue = getLValue(node)
-          var likelyType = getTypeWithMember(namedTypes, lvalue.key)
-          Object.assign(
-            lvalue.table.fields, lvalue.table.fields, likelyType.fields)
+        if (wasUnknownOrInferred) {
+          let lvalue = getLValue(node)
+          const likelyType = getTypeWithMember(namedTypes, lvalue.key, previousTypeName)
+          if (likelyType) {
+            Object.assign(lvalue.table.fields, lvalue.table.fields, likelyType.members)
+            lvalue.table.inferredTypeName = likelyType.name
+          }
         }
       }
     }
@@ -118,16 +129,31 @@ export default function extractTypes (node, namedTypes) {
 }
 
 // Returns the type in scope which has member with the given member
-function getTypeWithMember (scopeNamedTypes, member) {
-  // let candidate = null // the namedType containing memberPrefix which is the
+// previousType is an optional hint as to what type the identifier was judged as
+// The returned object is of the form
+// {members:(namedType members), name:(name of the namedType)}
+// It searches for the namedType with the lowest number of fields yet still
+// striclty greater than the previousType's fields count.
+function getTypeWithMember (scopeNamedTypes, member, previousType) {
+  let candidate = {}
+  const previousTypeLength = (previousType
+    ? Object.keys(scopeNamedTypes[previousType].fields).length
+    : 0
+  )
+  let mostPromisingTypeLength = Infinity
   for (let namedTypeName in scopeNamedTypes) {
     if (scopeNamedTypes.hasOwnProperty(namedTypeName)) {
       let namedTypeMembers = scopeNamedTypes[namedTypeName]
-      if (exactTableSearch(namedTypeMembers, member)) {
-        return namedTypeMembers
+      let currentTypeLength = Object.keys(namedTypeMembers.fields).length
+
+      if (currentTypeLength > previousTypeLength &&
+        currentTypeLength < mostPromisingTypeLength &&
+        exactTableSearch(namedTypeMembers, member)
+      ) {
+        mostPromisingTypeLength = currentTypeLength
+        candidate = {members: namedTypeMembers.fields, name: namedTypeName}
       }
     }
   }
-  // TODO: Apply an heuristic over all discovered types to
-  // provide more pertinent results
+  return candidate
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,11 +1,13 @@
 'use babel'
 
+import { Disposable } from 'atom'
+
 import LuaProvider from './provider'
+import { addOptionProviders, removeOptionProviders } from './options'
 import EmptyOptionProvider from './options/empty'
 import StdLibProvider from './options/stdlib'
 import LuaCompleteRcProvider from './options/luacompleterc'
-import { addOptionProviders, removeOptionProviders } from './options'
-import { Disposable } from 'atom'
+import { CompletionStrategy } from './extraction'
 
 window.__LOG__ = window.localStorage.getItem('__LOG__')
 
@@ -28,10 +30,21 @@ export default {
     },
     suggestUsedMembers: {
       order: 2,
-      type: 'boolean',
-      default: true,
-      title: 'Suggest used table members',
-      description: 'Suggest table members that you\'ve used in your code as opposed to just those you have explicitly set or defined'
+      type: 'integer',
+      default: CompletionStrategy.TYPE_ASSUMPTION,
+      title: 'Table member suggestion strategy',
+      description: 'Suggestion strategy for unknown identifiers. Choose to suggest nothing, suggest only already accessed members, or suggest members from an already existing type with similar members.',
+      enum: [ {
+          value: CompletionStrategy.VANILLA,
+          description: 'No inferred members'
+        }, {
+          value: CompletionStrategy.ALREADY_USED_ONLY,
+          description: 'Infers already accessed members only'
+        }, {
+          value: CompletionStrategy.TYPE_ASSUMPTION,
+          description: 'Infers from already defined types'
+        }
+      ]
     },
     minCharsPrefix: {
       order: 3,

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,7 @@ export default {
     suggestUsedMembers: {
       order: 2,
       type: 'integer',
-      default: CompletionStrategy.TYPE_ASSUMPTION,
+      default: CompletionStrategy.ALREADY_USED_ONLY,
       title: 'Table member suggestion strategy',
       description: 'Suggestion strategy for unknown identifiers. Choose to suggest nothing, suggest only already accessed members, or suggest members from an already existing type with similar members.',
       enum: [

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,10 +3,10 @@
 import { Disposable } from 'atom'
 
 import LuaProvider from './provider'
-import { addOptionProviders, removeOptionProviders } from './options'
 import EmptyOptionProvider from './options/empty'
 import StdLibProvider from './options/stdlib'
 import LuaCompleteRcProvider from './options/luacompleterc'
+import { addOptionProviders, removeOptionProviders } from './options'
 import { CompletionStrategy } from './extraction'
 
 window.__LOG__ = window.localStorage.getItem('__LOG__')
@@ -34,7 +34,8 @@ export default {
       default: CompletionStrategy.TYPE_ASSUMPTION,
       title: 'Table member suggestion strategy',
       description: 'Suggestion strategy for unknown identifiers. Choose to suggest nothing, suggest only already accessed members, or suggest members from an already existing type with similar members.',
-      enum: [ {
+      enum: [
+        {
           value: CompletionStrategy.VANILLA,
           description: 'No inferred members'
         }, {

--- a/lib/options/index.js
+++ b/lib/options/index.js
@@ -73,12 +73,7 @@ function mergeOptionsCached (previousOptions, newOptions, cache, merger) {
   return { options, newOptions, previousOptions }
 }
 
-const utils = {
-  reviveOptions, mergeOptions, mergeOptionsCached,
-  tableNew, booleanNew, functionNew, numberNew, unknownNew,
-  nilNew, tableSet, tableSetMetatable, tableGet,
-  tableGetMetatable, mergeTypeKnowledge
-}
+const utils = { reviveOptions, mergeOptions, mergeOptionsCached, tableNew, booleanNew, functionNew, numberNew, unknownNew, nilNew, tableSet, tableSetMetatable, tableGet, tableGetMetatable, mergeTypeKnowledge }
 
 let providers = []
 

--- a/lib/options/index.js
+++ b/lib/options/index.js
@@ -3,8 +3,8 @@
 import includes from 'lodash.includes'
 import {
   tableNew, booleanNew, functionNew, numberNew, unknownNew, nilNew,
-  tableSet, tableSetMetatable, tableGet, tableGetMetatable, tableRevertAndUnfreeze,
-  mergeTypeKnowledge, typeDefDeepClone
+  tableSet, tableSetMetatable, tableGet, tableGetMetatable,
+  tableRevertAndUnfreeze, mergeTypeKnowledge, typeDefDeepClone
 } from '../typedefs'
 
 function crawlAndRevive (typeDef, namedTypes, setter) {
@@ -34,7 +34,6 @@ function crawlAndRevive (typeDef, namedTypes, setter) {
   }
 }
 
-//Is this associating identifiers to their namedTypes?
 function reviveOptions (options) {
   if (!options || !options.namedTypes) { return options }
   let namedTypes = options.namedTypes
@@ -42,20 +41,24 @@ function reviveOptions (options) {
   for (let key in namedTypes) {
     crawlAndRevive(namedTypes[key], namedTypes, v => { namedTypes[key] = v })
   }
-  delete options.namedTypes
   return options
 }
 
 function mergeOptions (previousOptions, newOptions) {
   const newGlobal = newOptions.global
   const previousGlobal = previousOptions.global
-  const mergedOptions = Object.assign({}, previousOptions, newOptions)
+
+  let mergedOptions = Object.assign({}, previousOptions, newOptions)
+  Object.assign(mergedOptions.namedTypes, previousOptions.namedTypes, newOptions.namedTypes)
   tableRevertAndUnfreeze(newGlobal)
+
   const mergedGlobal = mergeTypeKnowledge(
     typeDefDeepClone(newGlobal),
     typeDefDeepClone(previousGlobal)
   )
-  if (mergedGlobal) { mergedOptions.global = mergedGlobal }
+  if (mergedGlobal) {
+    mergedOptions.global = mergedGlobal
+  }
   return mergedOptions
 }
 
@@ -64,11 +67,18 @@ function mergeOptionsCached (previousOptions, newOptions, cache, merger) {
     return cache
   }
   const options = utils.mergeOptions(previousOptions, newOptions)
-  if (merger) { merger(options, previousOptions, newOptions) }
+  if (merger) {
+    merger(options, previousOptions, newOptions)
+  }
   return { options, newOptions, previousOptions }
 }
 
-const utils = { reviveOptions, mergeOptions, mergeOptionsCached, tableNew, booleanNew, functionNew, numberNew, unknownNew, nilNew, tableSet, tableSetMetatable, tableGet, tableGetMetatable, mergeTypeKnowledge }
+const utils = {
+  reviveOptions, mergeOptions, mergeOptionsCached,
+  tableNew, booleanNew, functionNew, numberNew, unknownNew,
+  nilNew, tableSet, tableSetMetatable, tableGet,
+  tableGetMetatable, mergeTypeKnowledge
+}
 
 let providers = []
 
@@ -88,16 +98,27 @@ export function removeOptionProviders (v) {
 
 export default function getOptions (request) {
   providers.sort((a, b) => b.provider.priority - a.provider.priority)
+  // Accesses provider[index] and sets up a call to the next provider
+  // The function returned, when called, calls the next entry in chainProviders
   const chainProviders = (index) => {
     const providerSpec = providers[index]
-    if (!providerSpec) { return () => ({}) }
-    return async function () {
-      const nextGetOptions = chainProviders(index + 1)
-      const cacheKey = request.filePath
-      const cacheEntry = providerSpec.cache[cacheKey] || {}
-      const newCacheEntry = (await providerSpec.provider.getOptions(request, nextGetOptions, utils, cacheEntry))
-      providerSpec.cache[cacheKey] = newCacheEntry
-      return newCacheEntry.options
+    if (!providerSpec) { // terminal condition
+      return () => ({})
+    } else {
+      // Returns the options as returned by the first called provider.
+      // Note that it constructs the complete cache entry by giving the previous
+      // (the one from the lower priority provider) to the current provider
+      // and recovering it as its return value.
+      return async function () {
+        const nextGetOptions = chainProviders(index + 1)
+        const cacheKey = request.filePath
+        const cacheEntry = providerSpec.cache[cacheKey] || {}
+        const newCacheEntry = (
+          await providerSpec.provider.getOptions(request, nextGetOptions, utils, cacheEntry)
+        )
+        providerSpec.cache[cacheKey] = newCacheEntry
+        return newCacheEntry.options
+      }
     }
   }
   return Promise.resolve(chainProviders(0)())

--- a/lib/options/index.js
+++ b/lib/options/index.js
@@ -34,6 +34,7 @@ function crawlAndRevive (typeDef, namedTypes, setter) {
   }
 }
 
+//Is this associating identifiers to their namedTypes?
 function reviveOptions (options) {
   if (!options || !options.namedTypes) { return options }
   let namedTypes = options.namedTypes

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -48,26 +48,25 @@ export default class LuaProvider {
     const buffer = request.editor.getBuffer()
     let prefix = request.prefix
     const cursorIndex = buffer.characterIndexForPosition(request.bufferPosition)
+
+    prefix = prefix.replace(/^[\s]*/, '') // trim from front
     let charsToPrefix = cursorIndex - prefix.length
 
-    prefix = prefix.replace(/\s*$/, '') // trim from back
-    const prefLen = prefix.length
-    prefix = prefix.replace(/^\s*/, '') // trim from front
-    charsToPrefix += prefLen - prefix.length
+    prefix = prefix.replace(/[\s]*$/, '') // trim from back
 
     // is there a cleaner way of treating this?
     if (prefix === '.' || prefix === ':') {
       prefix = ''
-      charsToPrefix++
+      charsToPrefix += 1
     } else {
       // we don't do untriggered 0-length completions
       if (!request.activatedManually && prefix.length === 0) {
         return []
       }
     }
-
     __LOG__ && console.log('suggestions', request, prefix)
-
+    //Convenience function to querry text in the editor
+    //from offset `a` to offset `b`
     const textInIndexRange = (a, b) => buffer.getTextInRange([
       buffer.positionForCharacterIndex(a),
       buffer.positionForCharacterIndex(b)
@@ -76,7 +75,10 @@ export default class LuaProvider {
     const dotLine = buffer.getTextInRange([[dotEndPos.row, 0], dotEndPos])
     const dot = dotLine.match(/([^\s])?\s*$/)[1]
 
-    if (!request.activatedManually && dot !== '.' && dot !== ':' && prefix.length < Math.max(1, config.minCharsPrefix)) {
+    if ( !request.activatedManually &&
+      dot !== '.' && dot !== ':' &&
+      prefix.length < Math.max(1, config.minCharsPrefix)
+    ) {
       return []
     }
 
@@ -84,6 +86,7 @@ export default class LuaProvider {
     const options = await getOptions(request)
     options.cwd = options.cwd || path.dirname(request.filePath)
 
+    //Create an Analysis instance with the following querry arguments:
     const analysis = new Analysis(options, { prefix, charsToPrefix, dot })
 
     try {

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -49,24 +49,16 @@ export default class LuaProvider {
     let prefix = request.prefix
     const cursorIndex = buffer.characterIndexForPosition(request.bufferPosition)
 
-    prefix = prefix.replace(/^[\s]*/, '') // trim from front
+    prefix = prefix.replace(/^[\s.:]*/, '')
     let charsToPrefix = cursorIndex - prefix.length
 
     prefix = prefix.replace(/[\s]*$/, '') // trim from back
-
-    // is there a cleaner way of treating this?
-    if (prefix === '.' || prefix === ':') {
-      prefix = ''
-      charsToPrefix += 1
-    } else {
-      // we don't do untriggered 0-length completions
-      if (!request.activatedManually && prefix.length === 0) {
-        return []
-      }
+    // we don't do untriggered 0-length completions
+    if (!request.activatedManually && prefix.length === 0) {
+      return []
     }
     __LOG__ && console.log('suggestions', request, prefix)
-    //Convenience function to querry text in the editor
-    //from offset `a` to offset `b`
+    // Convenience function to querry text in the editor from offset `a` to offset `b`
     const textInIndexRange = (a, b) => buffer.getTextInRange([
       buffer.positionForCharacterIndex(a),
       buffer.positionForCharacterIndex(b)
@@ -75,7 +67,7 @@ export default class LuaProvider {
     const dotLine = buffer.getTextInRange([[dotEndPos.row, 0], dotEndPos])
     const dot = dotLine.match(/([^\s])?\s*$/)[1]
 
-    if ( !request.activatedManually &&
+    if (!request.activatedManually &&
       dot !== '.' && dot !== ':' &&
       prefix.length < Math.max(1, config.minCharsPrefix)
     ) {
@@ -85,9 +77,8 @@ export default class LuaProvider {
     request.filePath = getFilePath(request)
     const options = await getOptions(request)
     options.cwd = options.cwd || path.dirname(request.filePath)
-
-    //Create an Analysis instance with the following querry arguments:
-    const analysis = new Analysis(options, { prefix, charsToPrefix, dot })
+    // Create an Analysis instance with the following querry arguments:
+    const analysis = new Analysis(options, { prefix, charsToPrefix, dot }, options.namedTypes)
 
     try {
       analysis.write(textInIndexRange(0, charsToPrefix))
@@ -97,7 +88,6 @@ export default class LuaProvider {
       } else {
         analysis.write('__prefix_placeholder__.__prefix_placeholder__()')
       }
-
       let continuePos = cursorIndex
       if (request.activatedManually) {
         let nextChar = textInIndexRange(cursorIndex, cursorIndex + 1)
@@ -105,12 +95,10 @@ export default class LuaProvider {
           continuePos = charsToPrefix // parse the prefix as well
         }
       }
-
       analysis.end(textInIndexRange(continuePos, Infinity))
     } catch (ex) {
       if (__LOG__) { console.error(ex) }
     }
-
     return await analysis.solveQuery()
   }
 };

--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -117,7 +117,6 @@ export function nodeGetType (node, multipleTypes) {
 }
 
 // Returns dictionary {table, key} where table is the the resolved node value
-// and key the name of the node?
 export function getLValue (node) {
   if (!node) { return }
   const type = node.type

--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -116,6 +116,8 @@ export function nodeGetType (node, multipleTypes) {
   }
 }
 
+// Returns dictionary {table, key} where table is the the resolved node value
+// and key the name of the node?
 export function getLValue (node) {
   if (!node) { return }
   const type = node.type

--- a/lib/typedefs.js
+++ b/lib/typedefs.js
@@ -122,6 +122,7 @@ export const exactTableSearch = (table, member) => {
       return true
     }
   }
+  return false
 }
 
 const cloneDeepCustomizers = {

--- a/lib/typedefs.js
+++ b/lib/typedefs.js
@@ -90,8 +90,8 @@ export function* tableIterate (table) {
   }
 }
 
-//Searches in lua table keys with the given prefix, takes account of
-//the metatable.
+// Searches in lua table keys with the given prefix, takes account of
+// the metatable.
 export const tableSearch = (table, prefix) => {
   const results = []
   const search = (table) => {
@@ -99,8 +99,8 @@ export const tableSearch = (table, prefix) => {
       return
     }
     for (let [key, value] of tableIterate(table)) {
-      if (key.indexOf(prefix) === 0) { //adds into result the key if it starts
-        results.push({ key, typeDef: value }) //with prefix
+      if (key.indexOf(prefix) === 0) { // adds into result the key if it starts
+        results.push({ key, typeDef: value }) // with prefix
       }
     }
     const metatable = tableGetMetatable(table)
@@ -110,6 +110,18 @@ export const tableSearch = (table, prefix) => {
   }
   search(table)
   return results
+}
+
+// Returns true if the lua table has member member, otherwise false.
+export const exactTableSearch = (table, member) => {
+  if (!table) {
+    return false
+  }
+  for (let [key, __] of tableIterate(table)) {
+    if (key === member) { // adds into result the key if it starts
+      return true
+    }
+  }
 }
 
 const cloneDeepCustomizers = {
@@ -127,13 +139,12 @@ export function typeDefDeepClone (_typeDef) {
   const cache = new Map()
 
   function _deepClone (typeDef, setter) {
-    if (typeof typeDef !== 'object') {
+    if (typeof typeDef !== 'object') { // Terminal condition
       return
     }
-
-    // Fetch memoized value
+    // Return early if cache has an entry for typeDef.
     const cacheEntry = cache.get(typeDef)
-    if (cacheEntry) {
+    if (cacheEntry) { // Also terminal condition
       if (Array.isArray(cacheEntry)) {
         cacheEntry.push(setter)
       } else {
@@ -141,6 +152,7 @@ export function typeDefDeepClone (_typeDef) {
       }
       return
     }
+
     const setters = []
     cache.set(typeDef, setters)
 
@@ -216,6 +228,8 @@ const typePriority = {
   'table': 5
 }
 
+// Merges oldType to newType only if they are both tables, otherwise
+// returns the oldType or newType according to their priority.
 export function mergeTypeKnowledge (oldType, newType) {
   if (oldType === newType) { return oldType }
   const oldPriority = typePriority[oldType ? oldType.type : 'nil']

--- a/lib/typedefs.js
+++ b/lib/typedefs.js
@@ -90,6 +90,8 @@ export function* tableIterate (table) {
   }
 }
 
+//Searches in lua table keys with the given prefix, takes account of
+//the metatable.
 export const tableSearch = (table, prefix) => {
   const results = []
   const search = (table) => {
@@ -97,8 +99,9 @@ export const tableSearch = (table, prefix) => {
       return
     }
     for (let [key, value] of tableIterate(table)) {
-      if (key.indexOf(prefix) !== 0) { continue }
-      results.push({ key, typeDef: value })
+      if (key.indexOf(prefix) === 0) { //adds into result the key if it starts
+        results.push({ key, typeDef: value }) //with prefix
+      }
     }
     const metatable = tableGetMetatable(table)
     if (metatable && metatable.type === 'table') {


### PR DESCRIPTION
I found autocomplete-lua to be somewhat limited, especially when it comes to suggesting members for a variable which type is not specifically stated in the code. Indeed, the best it can do is suggest members already accessed before! This is very limiting and proves to be a great weakness.

I added a functionality, enabled in the settings menu using the `Table member suggestion strategy` option (by default disabled). Once activated, autocomplete-lua can use the `namedTypes` defined in the .luacompleterc (and anywhere else) to judge if a variable is of any type defined there when the members of an unknown type variable is accessed, and suggest all the members of that type (instead of just suggesting the ones explicitly stated in the code).

The caveats are as following:
 - The code has gone through very little testing (but works on my machine!).
 - There is use cases where you don't want that behavior. This why type deduction is just an option.
 - It might interfere with already existing option providers, because of the way I implemented namedType discovery.

I'll also add that I had no clue how your code worked (very little documentation and code commenting) and I might have just broken your design and architecture patterns. This is up to you to chose how to integrate the changes. Due to that, I also did some very minor refactoring left and right, this was part of the learning process of understanding the flow of your program.

This is the first time I'm doing a pull request or contributing to an open project, so I'm sorry if I'm breaking any conventions!

Note that I removed that line at `options/index.js:44` I'm not sure why it was there, but I needed it to get my code working, tell me if it breaks something!