### PR TITLE
Add descriptionMarkdown

### DIFF
--- a/lib/format.js
+++ b/lib/format.js
@@ -17,6 +17,7 @@ const emptyVariant = {}
 const emptyArray = []
 function formatVariant (key, typeDef, variant, trimSelf) {
   const description = variant.description || typeDef.description
+  const descriptionMarkdown = variant.descriptionMarkdown || typeDef.descriptionMarkdown
   const type = typeDef.type
   const link = variant.link || typeDef.link
   const args = variant.args || typeDef.args || emptyArray
@@ -29,6 +30,7 @@ function formatVariant (key, typeDef, variant, trimSelf) {
     type: isFunction ? 'function' : 'value',
     rightLabel: type === 'unknown' ? '' : type,
     description,
+    descriptionMarkdown,
     descriptionMoreURL: link
   }
 


### PR DESCRIPTION
adds property `descriptionMarkdown` from `autocomplete-plus` to provide the ability to use GitHub Markdown for more extensive descriptions. this feature was implemented not so long ago and it is still not even been described in the documentation, but is included in the latest releases and works well.

this option doesn't replace already existing `description` property so it won't cause any conflicts, but if `descriptionMarkdown` is set it will override the normal `description`.