### PR TITLE
LuaCompleteRcProvider skips unsaved files

### DIFF
--- a/lib/options/luacompleterc.js
+++ b/lib/options/luacompleterc.js
@@ -33,6 +33,10 @@ export default class LuaCompleteRcProvider {
       let filePath = request.editor.getBuffer().getPath()
       let rcPath = null
       let stat = null
+      
+      if (!filePath) {
+        return { options: (await previousOptionsPromise) }
+      }
 
       while (true) {
         const dirName = path.dirname(filePath)


### PR DESCRIPTION
`LuaCompleteRcProvider.getOptions` returns `previousOptions` when the `request.editor.getBuffer().getPath()` is `null` (which is the case for unsaved files).

This fixes issue #11 where `path.dirname` fails due to the argument being `null` instead of a valid path