### PR TITLE
Speed-up

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,68 +1,79 @@
 'use babel'
 
-import LuaProvider from './provider'
-import EmptyOptionProvider from './options/empty'
-import StdLibProvider from './options/stdlib'
-import LuaCompleteRcProvider from './options/luacompleterc'
-import { addOptionProviders, removeOptionProviders } from './options'
-import { Disposable } from 'atom'
+let LuaProvider
+
+function loadAutocompleteProvider () {
+  if (!LuaProvider) {
+    LuaProvider = require('./provider')
+  }
+}
+
+let EmptyOptionProvider, StdLibProvider, LuaCompleteRcProvider
+
+function loadLuaProviders () {
+  if (!EmptyOptionProvider) {
+    EmptyOptionProvider = require('./options/empty')
+  }
+  if (!StdLibProvider) {
+    StdLibProvider = require('./options/stdlib')
+  }
+  if (!LuaCompleteRcProvider) {
+    LuaCompleteRcProvider = require('./options/luacompleterc')
+  }
+}
+
+let addOptionProviders, removeOptionProviders, Disposable
+
+function loadLuaConsumer () {
+  if (!addOptionProviders || !removeOptionProviders) {
+    let options = require('./options')
+
+    addOptionProviders = options.addOptionProviders
+    removeOptionProviders = options.removeOptionProviders
+  }
+  if (!Disposable) {
+    let atom = require('atom')
+
+    Disposable = atom.Disposable
+  }
+}
 
 window.__LOG__ = window.localStorage.getItem('__LOG__')
 
 export default {
-  config: {
-    luaVersion: {
-      order: 0,
-      type: 'string',
-      default: '5.2',
-      enum: ['5.1', '5.2', '5.3', 'luajit-2.0'],
-      title: 'Default Lua version',
-      description: 'Can be overriden in .luacompleterc or by plugins'
-    },
-    useSnippets: {
-      order: 1,
-      type: 'boolean',
-      default: true,
-      title: 'Suggest snippets',
-      description: 'Complete functions with snippets of their arguments'
-    },
-    suggestUsedMembers: {
-      order: 2,
-      type: 'boolean',
-      default: true,
-      title: 'Suggest used table members',
-      description: 'Suggest table members that you\'ve used in your code as opposed to just those you have explicitly set or defined'
-    },
-    minCharsPrefix: {
-      order: 3,
-      type: 'integer',
-      default: 2,
-      minimum: 1,
-      title: 'Min chars to start completion',
-      description: 'The minimum number of typed characters required to start a completion'
-    },
-    excludeLowerPriority: {
-      order: 4,
-      type: 'boolean',
-      default: false,
-      title: 'Override lower priority providers',
-      description: 'Disable Atom\'s default keyword-based autocompletion provider and other lower priority providers'
-    },
-    inclusionPriority: {
-      order: 5,
-      type: 'integer',
-      default: 1,
-      minimum: 0,
-      title: 'Provider inclusion priority',
-      description: 'Priority relative to other autocomplete providers'
+  activate () {
+    this.idleCallbacks = new Set()
+
+    let callbackID
+
+    const installAutocompleteLuaDeps = () => {
+      loadAutocompleteProvider()
+      loadLuaProviders()
+      loadLuaConsumer()
     }
+
+    callbackID = window.requestIdleCallback(installAutocompleteLuaDeps)
+
+    this.idleCallbacks.add(callbackID)
+  },
+
+  deactivate () {
+    this.idleCallbacks.forEach(id =>
+       window.cancelIdleCallback(id)
+    )
+
+    this.idleCallbacks.clear()
   },
 
   getProvider () {
+    loadAutocompleteProvider()
+
     return new LuaProvider()
   },
 
   getOptionProviders () {
+    loadLuaProviders()
+
     return [
       new EmptyOptionProvider(),
       new StdLibProvider(),
@@ -71,6 +82,8 @@ export default {
   },
 
   onOptionProviders (providers) {
+    loadLuaConsumer()
+
     if (!Array.isArray(providers)) {
       providers = [providers]
     }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,53 @@
     "url": "https://github.com/dapetcu21/atom-autocomplete-lua/issues"
   },
   "main": "lib/index.js",
+  "configSchema": {
+      "luaVersion": {
+        "order": 0,
+        "type": "string",
+        "default": "5.2",
+        "enum": ["5.1", "5.2", "5.3", "luajit-2.0"],
+        "title": "Default Lua version",
+        "description": "Can be overriden in .luacompleterc or by plugins"
+      },
+      "useSnippets": {
+        "order": 1,
+        "type": "boolean",
+        "default": true,
+        "title": "Suggest snippets",
+        "description": "Complete functions with snippets of their arguments"
+      },
+      "suggestUsedMembers": {
+        "order": 2,
+        "type": "boolean",
+        "default": true,
+        "title": "Suggest used table members",
+        "description": "Suggest table members that you've used in your code as opposed to just those you have explicitly set or defined"
+      },
+      "minCharsPrefix": {
+        "order": 3,
+        "type": "integer",
+        "default": 2,
+        "minimum": 1,
+        "title": "Min chars to start completion",
+        "description": "The minimum number of typed characters required to start a completion"
+      },
+      "excludeLowerPriority": {
+        "order": 4,
+        "type": "boolean",
+        "default": false,
+        "title": "Override lower priority providers",
+        "description": "Disable Atom's default keyword-based autocompletion provider and other lower priority providers"
+      },
+      "inclusionPriority": {
+        "order": 5,
+        "type": "integer",
+        "default": 1,
+        "minimum": 0,
+        "title": "Provider inclusion priority",
+        "description": "Priority relative to other autocomplete providers"
+      }
+  },
   "providedServices": {
     "autocomplete.provider": {
       "versions": {


### PR DESCRIPTION
This pull-request improves activation time loading most files when Atom is idle.

It also moves `config` from `index.js` to `configSchema` in the `package.json` since static JSON loads faster than JS

Fixes #18 