### PR TITLE
Add lua 5.4 as a supported lua version

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ All options are optional. Here's what each option does:
 |--------|---------|-------------|
 |`global`|`{ type: 'table', fields: {} }`|The type definition of the global environment. Define additional fields on this table to declare globals available in your Lua environment. Read the [Type definitions](#type-definitions) section for more info.
 |`namedTypes`|`{}`|To avoid deep nesting and allow multiple places to reference a single type, you can define named types. Read the [Named types](#named-types) section for more info.
-|`luaVersion`|`"5.2"`|The version of Lua your code is targeting. Valid values are `"5.1"`, `"5.2"`, `"5.3"` and `"luajit-2.0"`.
+|`luaVersion`|`"5.2"`|The version of Lua your code is targeting. Valid values are `"5.1"`, `"5.2"`, `"5.3"`, `"5.4"` and `"luajit-2.0"`.
 |`packagePath`|`"./?.lua"`|The value of `LUA_PATH` used when resolving required modules.
 |`cwd`|`.`|The current directory used to resolve relative paths in `packagePath`. If `cwd` is relative, it's considered relative to the parent directory of `.luacompleterc`.
 

--- a/lib/analysis.js
+++ b/lib/analysis.js
@@ -44,12 +44,17 @@ export default class Analysis {
     this.requireCache = {}
 
     const luaVersion = options.luaVersion || config.luaVersion || '5.2'
+    if (luaVersion === 'luajit=2.0') {
+      luaVersion = '5.1'
+    } else if (luaVersion === '5.4') {
+      luaVersion = '5.3'
+    }
     luaparse.parse({
       wait: true,
       comments: false,
       ranges: true,
       scope: true,
-      luaVersion: luaVersion === 'luajit-2.0' ? '5.1' : luaVersion,
+      luaVersion: luaVersion,
       onCreateNode: this._onCreateNode,
       onCreateScope: this._onCreateScope,
       onDestroyScope: this._onDestroyScope,

--- a/lib/options/stdlib.js
+++ b/lib/options/stdlib.js
@@ -10,6 +10,8 @@ function getOptions (luaVersion) {
       return require('../stdlib/5_2.json')
     case '5.3':
       return require('../stdlib/5_3.json')
+    case '5.4':
+      return require('../stdlib/5_4.json')
     case 'luajit-2.0':
       return require('../stdlib/luajit-2_0.json')
   }

--- a/lib/stdlib/5_4.json
+++ b/lib/stdlib/5_4.json
@@ -1,0 +1,1613 @@
+{
+  "global": {
+    "type": "table",
+    "fields": {
+      "_VERSION": {
+        "link": "https://www.lua.org/manual/5.4/manual.html#pdf-_VERSION",
+        "description": "A global variable (not a function) that holds a string containing the running Lua version. The current value of this variable is \"Lua 5.4\".",
+        "type": "string"
+      },
+      "assert": {
+        "link": "https://www.lua.org/manual/5.4/manual.html#pdf-assert",
+        "description": "Raises an error if the value of its argument v is false (i.e., nil or false); otherwise, returns all its arguments. In case of error, message is the error object; when absent, it defaults to \"assertion failed!\"",
+        "type": "function",
+        "args": [
+          {
+            "name": "v"
+          }
+        ],
+        "argsDisplay": "v [, message]"
+      },
+      "collectgarbage": {
+        "link": "https://www.lua.org/manual/5.4/manual.html#pdf-collectgarbage",
+        "description": "This function is a generic interface to the garbage collector. It performs different functions according to its first argument, opt:",
+        "type": "function",
+        "args": [],
+        "argsDisplay": "[opt [, arg]]"
+      },
+      "dofile": {
+        "link": "https://www.lua.org/manual/5.4/manual.html#pdf-dofile",
+        "description": "Opens the named file and executes its content as a Lua chunk. When called without arguments, dofile executes the content of the standard input (stdin). Returns all values returned by the chunk. In case of errors, dofile propagates the error to its caller. (That is, dofile does not run in protected mode.)",
+        "type": "function",
+        "args": [],
+        "argsDisplay": "[filename]"
+      },
+      "error": {
+        "link": "https://www.lua.org/manual/5.4/manual.html#pdf-error",
+        "description": "Raises an error (see §2.3) with @{message} as the error object. This function never returns.",
+        "type": "function",
+        "args": [
+          {
+            "name": "message"
+          }
+        ],
+        "argsDisplay": "message [, level]"
+      },
+      "getmetatable": {
+        "link": "https://www.lua.org/manual/5.4/manual.html#pdf-getmetatable",
+        "description": "If object does not have a metatable, returns nil. Otherwise, if the object's metatable has a __metatable field, returns the associated value. Otherwise, returns the metatable of the given object.",
+        "type": "function",
+        "args": [
+          {
+            "name": "object"
+          }
+        ],
+        "argsDisplay": "object"
+      },
+      "ipairs": {
+        "link": "https://www.lua.org/manual/5.4/manual.html#pdf-ipairs",
+        "description": "Returns three values (an iterator function, the table t, and 0) so that the construction",
+        "type": "function",
+        "args": [
+          {
+            "name": "t"
+          }
+        ],
+        "argsDisplay": "t"
+      },
+      "load": {
+        "link": "https://www.lua.org/manual/5.4/manual.html#pdf-load",
+        "description": "Loads a chunk.",
+        "type": "function",
+        "args": [
+          {
+            "name": "chunk"
+          }
+        ],
+        "argsDisplay": "chunk [, chunkname [, mode [, env]]]"
+      },
+      "loadfile": {
+        "link": "https://www.lua.org/manual/5.4/manual.html#pdf-loadfile",
+        "description": "Similar to load, but gets the chunk from file filename or from the standard input, if no file name is given.",
+        "type": "function",
+        "args": [],
+        "argsDisplay": "[filename [, mode [, env]]]"
+      },
+      "next": {
+        "link": "https://www.lua.org/manual/5.4/manual.html#pdf-next",
+        "description": "Allows a program to traverse all fields of a table. Its first argument is a table and its second argument is an index in this table. A call to next returns the next index of the table and its associated value. When called with nil as its second argument, next returns an initial index and its associated value. When called with the last index, or with nil in an empty table, next returns nil. If the second argument is absent, then it is interpreted as nil. In particular, you can use next(t) to check whether a table is empty.",
+        "type": "function",
+        "args": [
+          {
+            "name": "table"
+          }
+        ],
+        "argsDisplay": "table [, index]"
+      },
+      "pairs": {
+        "link": "https://www.lua.org/manual/5.4/manual.html#pdf-pairs",
+        "description": "If t has a metamethod __pairs, calls it with t as argument and returns the first three results from the call.",
+        "type": "function",
+        "args": [
+          {
+            "name": "t"
+          }
+        ],
+        "argsDisplay": "t"
+      },
+      "pcall": {
+        "link": "https://www.lua.org/manual/5.4/manual.html#pdf-pcall",
+        "description": "Calls the function f with the given arguments in protected mode. This means that any error inside f is not propagated; instead, pcall catches the error and returns a status code. Its first result is the status code (a boolean), which is true if the call succeeds without errors. In such case, pcall also returns all results from the call, after this first result. In case of any error, pcall returns false plus the error object. Note that errors caught by pcall do not call a message handler.",
+        "type": "function",
+        "args": [
+          {
+            "name": "f"
+          }
+        ],
+        "argsDisplay": "f [, arg1, ···]"
+      },
+      "print": {
+        "link": "https://www.lua.org/manual/5.4/manual.html#pdf-print",
+        "description": "Receives any number of arguments and prints their values to stdout, converting each argument to a string following the same rules of tostring.",
+        "type": "function",
+        "args": [],
+        "argsDisplay": "···"
+      },
+      "rawequal": {
+        "link": "https://www.lua.org/manual/5.4/manual.html#pdf-rawequal",
+        "description": "Checks whether v1 is equal to v2, without invoking the __eq metamethod. Returns a boolean.",
+        "type": "function",
+        "args": [
+          {
+            "name": "v1"
+          },
+          {
+            "name": "v2"
+          }
+        ],
+        "argsDisplay": "v1, v2"
+      },
+      "rawget": {
+        "link": "https://www.lua.org/manual/5.4/manual.html#pdf-rawget",
+        "description": "Gets the real value of table[index], without using the __index metavalue. table must be a table; index may be any value.",
+        "type": "function",
+        "args": [
+          {
+            "name": "table"
+          },
+          {
+            "name": "index"
+          }
+        ],
+        "argsDisplay": "table, index"
+      },
+      "rawlen": {
+        "link": "https://www.lua.org/manual/5.4/manual.html#pdf-rawlen",
+        "description": "Returns the length of the object v, which must be a table or a string, without invoking the __len metamethod. Returns an integer.",
+        "type": "function",
+        "args": [
+          {
+            "name": "v"
+          }
+        ],
+        "argsDisplay": "v"
+      },
+      "rawset": {
+        "link": "https://www.lua.org/manual/5.4/manual.html#pdf-rawset",
+        "description": "Sets the real value of table[index] to value, without using the __newindex metavalue. table must be a table, index any value different from nil and NaN, and value any Lua value.",
+        "type": "function",
+        "args": [
+          {
+            "name": "table"
+          },
+          {
+            "name": "index"
+          },
+          {
+            "name": "value"
+          }
+        ],
+        "argsDisplay": "table, index, value"
+      },
+      "require": {
+        "link": "https://www.lua.org/manual/5.4/manual.html#pdf-require",
+        "description": "Loads the given module. The function starts by looking into the package.loaded table to determine whether modname is already loaded. If it is, then require returns the value stored at package.loaded[modname]. (The absence of a second result in this case signals that this call did not have to load the module.) Otherwise, it tries to find a loader for the module.",
+        "type": "function",
+        "args": [
+          {
+            "name": "modname"
+          }
+        ],
+        "argsDisplay": "modname"
+      },
+      "select": {
+        "link": "https://www.lua.org/manual/5.4/manual.html#pdf-select",
+        "description": "If index is a number, returns all arguments after argument number index; a negative number indexes from the end (-1 is the last argument). Otherwise, index must be the string \"#\", and select returns the total number of extra arguments it received.",
+        "type": "function",
+        "args": [
+          {
+            "name": "index"
+          }
+        ],
+        "argsDisplay": "index, ···"
+      },
+      "setmetatable": {
+        "link": "https://www.lua.org/manual/5.4/manual.html#pdf-setmetatable",
+        "description": "Sets the metatable for the given table. If metatable is nil, removes the metatable of the given table. If the original metatable has a __metatable field, raises an error.",
+        "type": "function",
+        "args": [
+          {
+            "name": "table"
+          },
+          {
+            "name": "metatable"
+          }
+        ],
+        "argsDisplay": "table, metatable"
+      },
+      "tonumber": {
+        "link": "https://www.lua.org/manual/5.4/manual.html#pdf-tonumber",
+        "description": "When called with no base, tonumber tries to convert its argument to a number. If the argument is already a number or a string convertible to a number, then tonumber returns this number; otherwise, it returns fail.",
+        "type": "function",
+        "args": [
+          {
+            "name": "e"
+          }
+        ],
+        "argsDisplay": "e [, base]"
+      },
+      "tostring": {
+        "link": "https://www.lua.org/manual/5.4/manual.html#pdf-tostring",
+        "description": "Receives a value of any type and converts it to a string in a human-readable format.",
+        "type": "function",
+        "args": [
+          {
+            "name": "v"
+          }
+        ],
+        "argsDisplay": "v"
+      },
+      "type": {
+        "link": "https://www.lua.org/manual/5.4/manual.html#pdf-type",
+        "description": "Returns the type of its only argument, coded as a string. The possible results of this function are \"nil\" (a string, not the value nil), \"number\", \"string\", \"boolean\", \"table\", \"function\", \"thread\", and \"userdata\".",
+        "type": "function",
+        "args": [
+          {
+            "name": "v"
+          }
+        ],
+        "argsDisplay": "v"
+      },
+      "warn": {
+        "link": "https://www.lua.org/manual/5.4/manual.html#pdf-warn",
+        "description": "Emits a warning with a message composed by the concatenation of all its arguments (which should be strings).",
+        "type": "function",
+        "args": [
+          {
+            "name": "msg1"
+          }
+        ],
+        "argsDisplay": "msg1, ···"
+      },
+      "xpcall": {
+        "link": "https://www.lua.org/manual/5.4/manual.html#pdf-xpcall",
+        "description": "This function is similar to pcall, except that it sets a new message handler msgh.",
+        "type": "function",
+        "args": [
+          {
+            "name": "f"
+          },
+          {
+            "name": "msgh"
+          }
+        ],
+        "argsDisplay": "f, msgh [, arg1, ···]"
+      },
+      "coroutine": {
+        "link": "https://www.lua.org/manual/5.4/manual.html#6.2",
+        "description": "This library comprises the operations to manipulate coroutines, which come inside the table coroutine. See §2.6 for a general description of coroutines.",
+        "type": "table",
+        "fields": {
+          "close": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-coroutine.close",
+            "description": "Closes coroutine co, that is, closes all its pending to-be-closed variables and puts the coroutine in a dead state. The given coroutine must be dead or suspended. In case of error closing some variable, returns false plus the error object; otherwise returns true.",
+            "type": "function",
+            "args": [
+              {
+                "name": "co"
+              }
+            ],
+            "argsDisplay": "co"
+          },
+          "create": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-coroutine.create",
+            "description": "Creates a new coroutine, with body f. f must be a function. Returns this new coroutine, an object with type \"thread\".",
+            "type": "function",
+            "args": [
+              {
+                "name": "f"
+              }
+            ],
+            "argsDisplay": "f"
+          },
+          "isyieldable": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-coroutine.isyieldable",
+            "description": "Returns true when the coroutine co can yield. The default for co is the running coroutine.",
+            "type": "function",
+            "args": [],
+            "argsDisplay": "[co]"
+          },
+          "resume": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-coroutine.resume",
+            "description": "Starts or continues the execution of coroutine co. The first time you resume a coroutine, it starts running its body. The values val1, ... are passed as the arguments to the body function. If the coroutine has yielded, resume restarts it; the values val1, ... are passed as the results from the yield.",
+            "type": "function",
+            "args": [
+              {
+                "name": "co"
+              }
+            ],
+            "argsDisplay": "co [, val1, ···]"
+          },
+          "running": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-coroutine.running",
+            "description": "Returns the running coroutine plus a boolean, true when the running coroutine is the main one.",
+            "type": "function",
+            "args": [],
+            "argsDisplay": ""
+          },
+          "status": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-coroutine.status",
+            "description": "Returns the status of the coroutine co, as a string: \"running\", if the coroutine is running (that is, it is the one that called status); \"suspended\", if the coroutine is suspended in a call to yield, or if it has not started running yet; \"normal\" if the coroutine is active but not running (that is, it has resumed another coroutine); and \"dead\" if the coroutine has finished its body function, or if it has stopped with an error.",
+            "type": "function",
+            "args": [
+              {
+                "name": "co"
+              }
+            ],
+            "argsDisplay": "co"
+          },
+          "wrap": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-coroutine.wrap",
+            "description": "Creates a new coroutine, with body f; f must be a function. Returns a function that resumes the coroutine each time it is called. Any arguments passed to this function behave as the extra arguments to resume. The function returns the same values returned by resume, except the first boolean. In case of error, the function closes the coroutine and propagates the error.",
+            "type": "function",
+            "args": [
+              {
+                "name": "f"
+              }
+            ],
+            "argsDisplay": "f"
+          },
+          "yield": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-coroutine.yield",
+            "description": "Suspends the execution of the calling coroutine. Any arguments to yield are passed as extra results to resume.",
+            "type": "function",
+            "args": [],
+            "argsDisplay": "···"
+          }
+        }
+      },
+      "debug": {
+        "link": "https://www.lua.org/manual/5.4/manual.html#6.10",
+        "description": "This library provides the functionality of the debug interface (§4.7) to Lua programs. You should exert care when using this library. Several of its functions violate basic assumptions about Lua code (e.g., that variables local to a function cannot be accessed from outside; that userdata metatables cannot be changed by Lua code; that Lua programs do not crash) and therefore can compromise otherwise secure code. Moreover, some functions in this library may be slow.",
+        "type": "table",
+        "fields": {
+          "debug": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-debug.debug",
+            "description": "Enters an interactive mode with the user, running each string that the user enters. Using simple commands and other debug facilities, the user can inspect global and local variables, change their values, evaluate expressions, and so on. A line containing only the word cont finishes this function, so that the caller continues its execution.",
+            "type": "function",
+            "args": [],
+            "argsDisplay": ""
+          },
+          "gethook": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-debug.gethook",
+            "description": "Returns the current hook settings of the thread, as three values: the current hook function, the current hook mask, and the current hook count, as set by the debug.sethook function.",
+            "type": "function",
+            "args": [],
+            "argsDisplay": "[thread]"
+          },
+          "getinfo": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-debug.getinfo",
+            "description": "Returns a table with information about a function. You can give the function directly or you can give a number as the value of f, which means the function running at level f of the call stack of the given thread: level 0 is the current function (getinfo itself); level 1 is the function that called getinfo (except for tail calls, which do not count in the stack); and so on. If f is a number greater than the number of active functions, then getinfo returns fail.",
+            "type": "function",
+            "args": [],
+            "argsDisplay": "[thread,] f [, what]"
+          },
+          "getlocal": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-debug.getlocal",
+            "description": "This function returns the name and the value of the local variable with index local of the function at level f of the stack. This function accesses not only explicit local variables, but also parameters and temporary values.",
+            "type": "function",
+            "args": [],
+            "argsDisplay": "[thread,] f, local"
+          },
+          "getmetatable": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-debug.getmetatable",
+            "description": "Returns the metatable of the given value or nil if it does not have a metatable.",
+            "type": "function",
+            "args": [
+              {
+                "name": "value"
+              }
+            ],
+            "argsDisplay": "value"
+          },
+          "getregistry": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-debug.getregistry",
+            "description": "Returns the registry table (see §4.3).",
+            "type": "function",
+            "args": [],
+            "argsDisplay": ""
+          },
+          "getupvalue": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-debug.getupvalue",
+            "description": "This function returns the name and the value of the upvalue with index up of the function f. The function returns fail if there is no upvalue with the given index.",
+            "type": "function",
+            "args": [
+              {
+                "name": "f"
+              },
+              {
+                "name": "up"
+              }
+            ],
+            "argsDisplay": "f, up"
+          },
+          "getuservalue": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-debug.getuservalue",
+            "description": "Returns the n-th user value associated to the userdata u plus a boolean, false if the userdata does not have that value.",
+            "type": "function",
+            "args": [
+              {
+                "name": "u"
+              },
+              {
+                "name": "n"
+              }
+            ],
+            "argsDisplay": "u, n"
+          },
+          "setcstacklimit": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-debug.setcstacklimit",
+            "description": "Sets a new limit for the C stack. This limit controls how deeply nested calls can go in Lua, with the intent of avoiding a stack overflow. A limit too small restricts recursive calls pointlessly; a limit too large exposes the interpreter to stack-overflow crashes. Unfortunately, there is no way to know a priori the maximum safe limit for a platform.",
+            "type": "function",
+            "args": [
+              {
+                "name": "limit"
+              }
+            ],
+            "argsDisplay": "limit"
+          },
+          "sethook": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-debug.sethook",
+            "description": "Sets the given function as the debug hook. The string mask and the number count describe when the hook will be called. The string mask may have any combination of the following characters, with the given meaning:",
+            "type": "function",
+            "args": [],
+            "argsDisplay": "[thread,] hook, mask [, count]"
+          },
+          "setlocal": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-debug.setlocal",
+            "description": "This function assigns the value value to the local variable with index local of the function at level level of the stack. The function returns fail if there is no local variable with the given index, and raises an error when called with a level out of range. (You can call getinfo to check whether the level is valid.) Otherwise, it returns the name of the local variable.",
+            "type": "function",
+            "args": [],
+            "argsDisplay": "[thread,] level, local, value"
+          },
+          "setmetatable": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-debug.setmetatable",
+            "description": "Sets the metatable for the given value to the given table (which can be nil). Returns value.",
+            "type": "function",
+            "args": [
+              {
+                "name": "value"
+              },
+              {
+                "name": "table"
+              }
+            ],
+            "argsDisplay": "value, table"
+          },
+          "setupvalue": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-debug.setupvalue",
+            "description": "This function assigns the value value to the upvalue with index up of the function f. The function returns fail if there is no upvalue with the given index. Otherwise, it returns the name of the upvalue.",
+            "type": "function",
+            "args": [
+              {
+                "name": "f"
+              },
+              {
+                "name": "up"
+              },
+              {
+                "name": "value"
+              }
+            ],
+            "argsDisplay": "f, up, value"
+          },
+          "setuservalue": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-debug.setuservalue",
+            "description": "Sets the given value as the n-th user value associated to the given udata. udata must be a full userdata.",
+            "type": "function",
+            "args": [
+              {
+                "name": "udata"
+              },
+              {
+                "name": "value"
+              },
+              {
+                "name": "n"
+              }
+            ],
+            "argsDisplay": "udata, value, n"
+          },
+          "traceback": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-debug.traceback",
+            "description": "If message is present but is neither a string nor nil, this function returns message without further processing. Otherwise, it returns a string with a traceback of the call stack. The optional message string is appended at the beginning of the traceback. An optional level number tells at which level to start the traceback (default is 1, the function calling traceback).",
+            "type": "function",
+            "args": [],
+            "argsDisplay": "[thread,] [message [, level]]"
+          },
+          "upvalueid": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-debug.upvalueid",
+            "description": "Returns a unique identifier (as a light userdata) for the upvalue numbered n from the given function.",
+            "type": "function",
+            "args": [
+              {
+                "name": "f"
+              },
+              {
+                "name": "n"
+              }
+            ],
+            "argsDisplay": "f, n"
+          },
+          "upvaluejoin": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-debug.upvaluejoin",
+            "description": "Make the n1-th upvalue of the Lua closure f1 refer to the n2-th upvalue of the Lua closure f2.",
+            "type": "function",
+            "args": [
+              {
+                "name": "f1"
+              },
+              {
+                "name": "n1"
+              },
+              {
+                "name": "f2"
+              },
+              {
+                "name": "n2"
+              }
+            ],
+            "argsDisplay": "f1, n1, f2, n2"
+          }
+        }
+      },
+      "io": {
+        "link": "https://www.lua.org/manual/5.4/manual.html#6.8",
+        "description": "The I/O library provides two different styles for file manipulation. The first one uses implicit file handles; that is, there are operations to set a default input file and a default output file, and all input/output operations are done over these default files. The second style uses explicit file handles.",
+        "type": "table",
+        "fields": {
+          "close": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-io.close",
+            "description": "Equivalent to file:close(). Without a file, closes the default output file.",
+            "type": "function",
+            "args": [],
+            "argsDisplay": "[file]"
+          },
+          "flush": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-io.flush",
+            "description": "Equivalent to io.output():flush().",
+            "type": "function",
+            "args": [],
+            "argsDisplay": ""
+          },
+          "input": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-io.input",
+            "description": "When called with a file name, it opens the named file (in text mode), and sets its handle as the default input file. When called with a file handle, it simply sets this file handle as the default input file. When called without arguments, it returns the current default input file.",
+            "type": "function",
+            "args": [],
+            "argsDisplay": "[file]"
+          },
+          "lines": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-io.lines",
+            "description": "Opens the given file name in read mode and returns an iterator function that works like file:lines(···) over the opened file. When the iterator function fails to read any value, it automatically closes the file. Besides the iterator function, io.lines returns three other values: two nil values as placeholders, plus the created file handle. Therefore, when used in a generic for loop, the file is closed also if the loop is interrupted by an error or a break.",
+            "type": "function",
+            "args": [],
+            "argsDisplay": "[filename, ···]"
+          },
+          "open": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-io.open",
+            "description": "This function opens a file, in the mode specified in the string mode. In case of success, it returns a new file handle.",
+            "type": "function",
+            "args": [
+              {
+                "name": "filename"
+              }
+            ],
+            "argsDisplay": "filename [, mode]",
+            "returnTypes": [
+              {
+                "type": "ref",
+                "name": "file"
+              }
+            ]
+          },
+          "output": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-io.output",
+            "description": "Similar to io.input, but operates over the default output file.",
+            "type": "function",
+            "args": [],
+            "argsDisplay": "[file]"
+          },
+          "popen": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-io.popen",
+            "description": "This function is system dependent and is not available on all platforms.",
+            "type": "function",
+            "args": [
+              {
+                "name": "prog"
+              }
+            ],
+            "argsDisplay": "prog [, mode]",
+            "returnTypes": [
+              {
+                "type": "ref",
+                "name": "file"
+              }
+            ]
+          },
+          "read": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-io.read",
+            "description": "Equivalent to io.input():read(···).",
+            "type": "function",
+            "args": [],
+            "argsDisplay": "···"
+          },
+          "stderr": {
+            "type": "ref",
+            "name": "file"
+          },
+          "stdin": {
+            "type": "ref",
+            "name": "file"
+          },
+          "stdout": {
+            "type": "ref",
+            "name": "file"
+          },
+          "tmpfile": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-io.tmpfile",
+            "description": "In case of success, returns a handle for a temporary file. This file is opened in update mode and it is automatically removed when the program ends.",
+            "type": "function",
+            "args": [],
+            "argsDisplay": "",
+            "returnTypes": [
+              {
+                "type": "ref",
+                "name": "file"
+              }
+            ]
+          },
+          "type": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-io.type",
+            "description": "Checks whether obj is a valid file handle. Returns the string \"file\" if obj is an open file handle, \"closed file\" if obj is a closed file handle, or fail if obj is not a file handle.",
+            "type": "function",
+            "args": [
+              {
+                "name": "obj"
+              }
+            ],
+            "argsDisplay": "obj"
+          },
+          "write": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-io.write",
+            "description": "Equivalent to io.output():write(···).",
+            "type": "function",
+            "args": [],
+            "argsDisplay": "···"
+          }
+        }
+      },
+      "math": {
+        "link": "https://www.lua.org/manual/5.4/manual.html#6.7",
+        "description": "This library provides basic mathematical functions. It provides all its functions and constants inside the table math. Functions with the annotation \"integer/float\" give integer results for integer arguments and float results for non-integer arguments. The rounding functions math.ceil, math.floor, and math.modf return an integer when the result fits in the range of an integer, or a float otherwise.",
+        "type": "table",
+        "fields": {
+          "abs": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-math.abs",
+            "description": "Returns the maximum value between x and -x. (integer/float)",
+            "type": "function",
+            "args": [
+              {
+                "name": "x"
+              }
+            ],
+            "argsDisplay": "x"
+          },
+          "acos": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-math.acos",
+            "description": "Returns the arc cosine of x (in radians).",
+            "type": "function",
+            "args": [
+              {
+                "name": "x"
+              }
+            ],
+            "argsDisplay": "x"
+          },
+          "asin": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-math.asin",
+            "description": "Returns the arc sine of x (in radians).",
+            "type": "function",
+            "args": [
+              {
+                "name": "x"
+              }
+            ],
+            "argsDisplay": "x"
+          },
+          "atan": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-math.atan",
+            "description": "Returns the arc tangent of y/x (in radians), but uses the signs of both arguments to find the quadrant of the result. It also handles correctly the case of x being zero.",
+            "type": "function",
+            "args": [
+              {
+                "name": "y"
+              }
+            ],
+            "argsDisplay": "y [, x]"
+          },
+          "ceil": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-math.ceil",
+            "description": "Returns the smallest integral value greater than or equal to x.",
+            "type": "function",
+            "args": [
+              {
+                "name": "x"
+              }
+            ],
+            "argsDisplay": "x"
+          },
+          "cos": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-math.cos",
+            "description": "Returns the cosine of x (assumed to be in radians).",
+            "type": "function",
+            "args": [
+              {
+                "name": "x"
+              }
+            ],
+            "argsDisplay": "x"
+          },
+          "deg": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-math.deg",
+            "description": "Converts the angle x from radians to degrees.",
+            "type": "function",
+            "args": [
+              {
+                "name": "x"
+              }
+            ],
+            "argsDisplay": "x"
+          },
+          "exp": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-math.exp",
+            "description": "Returns the value ex (where e is the base of natural logarithms).",
+            "type": "function",
+            "args": [
+              {
+                "name": "x"
+              }
+            ],
+            "argsDisplay": "x"
+          },
+          "floor": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-math.floor",
+            "description": "Returns the largest integral value less than or equal to x.",
+            "type": "function",
+            "args": [
+              {
+                "name": "x"
+              }
+            ],
+            "argsDisplay": "x"
+          },
+          "fmod": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-math.fmod",
+            "description": "Returns the remainder of the division of x by y that rounds the quotient towards zero. (integer/float)",
+            "type": "function",
+            "args": [
+              {
+                "name": "x"
+              },
+              {
+                "name": "y"
+              }
+            ],
+            "argsDisplay": "x, y"
+          },
+          "huge": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-math.huge",
+            "description": "The float value HUGE_VAL, a value greater than any other numeric value.",
+            "type": "unknown"
+          },
+          "log": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-math.log",
+            "description": "Returns the logarithm of x in the given base. The default for base is e (so that the function returns the natural logarithm of x).",
+            "type": "function",
+            "args": [
+              {
+                "name": "x"
+              }
+            ],
+            "argsDisplay": "x [, base]"
+          },
+          "max": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-math.max",
+            "description": "Returns the argument with the maximum value, according to the Lua operator <.",
+            "type": "function",
+            "args": [
+              {
+                "name": "x"
+              }
+            ],
+            "argsDisplay": "x, ···"
+          },
+          "maxinteger": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-math.maxinteger",
+            "description": "An integer with the maximum value for an integer.",
+            "type": "unknown"
+          },
+          "min": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-math.min",
+            "description": "Returns the argument with the minimum value, according to the Lua operator <.",
+            "type": "function",
+            "args": [
+              {
+                "name": "x"
+              }
+            ],
+            "argsDisplay": "x, ···"
+          },
+          "mininteger": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-math.mininteger",
+            "description": "An integer with the minimum value for an integer.",
+            "type": "unknown"
+          },
+          "modf": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-math.modf",
+            "description": "Returns the integral part of x and the fractional part of x. Its second result is always a float.",
+            "type": "function",
+            "args": [
+              {
+                "name": "x"
+              }
+            ],
+            "argsDisplay": "x"
+          },
+          "pi": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-math.pi",
+            "description": "The value of π.",
+            "type": "number"
+          },
+          "rad": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-math.rad",
+            "description": "Converts the angle x from degrees to radians.",
+            "type": "function",
+            "args": [
+              {
+                "name": "x"
+              }
+            ],
+            "argsDisplay": "x"
+          },
+          "random": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-math.random",
+            "description": "When called without arguments, returns a pseudo-random float with uniform distribution in the range [0,1). When called with two integers m and n, math.random returns a pseudo-random integer with uniform distribution in the range [m, n]. The call math.random(n), for a positive n, is equivalent to math.random(1,n). The call math.random(0) produces an integer with all bits (pseudo)random.",
+            "type": "function",
+            "args": [],
+            "argsDisplay": "[m [, n]]"
+          },
+          "randomseed": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-math.randomseed",
+            "description": "When called with at least one argument, the integer parameters x and y are joined into a 128-bit seed that is used to reinitialize the pseudo-random generator; equal seeds produce equal sequences of numbers. The default for y is zero.",
+            "type": "function",
+            "args": [],
+            "argsDisplay": "[x [, y]]"
+          },
+          "sin": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-math.sin",
+            "description": "Returns the sine of x (assumed to be in radians).",
+            "type": "function",
+            "args": [
+              {
+                "name": "x"
+              }
+            ],
+            "argsDisplay": "x"
+          },
+          "sqrt": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-math.sqrt",
+            "description": "Returns the square root of x. (You can also use the expression x^0.5 to compute this value.)",
+            "type": "function",
+            "args": [
+              {
+                "name": "x"
+              }
+            ],
+            "argsDisplay": "x"
+          },
+          "tan": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-math.tan",
+            "description": "Returns the tangent of x (assumed to be in radians).",
+            "type": "function",
+            "args": [
+              {
+                "name": "x"
+              }
+            ],
+            "argsDisplay": "x"
+          },
+          "tointeger": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-math.tointeger",
+            "description": "If the value x is convertible to an integer, returns that integer. Otherwise, returns fail.",
+            "type": "function",
+            "args": [
+              {
+                "name": "x"
+              }
+            ],
+            "argsDisplay": "x"
+          },
+          "type": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-math.type",
+            "description": "Returns \"integer\" if x is an integer, \"float\" if it is a float, or fail if x is not a number.",
+            "type": "function",
+            "args": [
+              {
+                "name": "x"
+              }
+            ],
+            "argsDisplay": "x"
+          },
+          "ult": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-math.ult",
+            "description": "Returns a boolean, true if and only if integer m is below integer n when they are compared as unsigned integers.",
+            "type": "function",
+            "args": [
+              {
+                "name": "m"
+              },
+              {
+                "name": "n"
+              }
+            ],
+            "argsDisplay": "m, n"
+          }
+        }
+      },
+      "os": {
+        "link": "https://www.lua.org/manual/5.4/manual.html#6.9",
+        "description": "This library is implemented through table os.",
+        "type": "table",
+        "fields": {
+          "clock": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-os.clock",
+            "description": "Returns an approximation of the amount in seconds of CPU time used by the program, as returned by the underlying ISO C function clock.",
+            "type": "function",
+            "args": [],
+            "argsDisplay": ""
+          },
+          "date": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-os.date",
+            "description": "Returns a string or a table containing date and time, formatted according to the given string format.",
+            "type": "function",
+            "args": [],
+            "argsDisplay": "[format [, time]]"
+          },
+          "difftime": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-os.difftime",
+            "description": "Returns the difference, in seconds, from time t1 to time t2 (where the times are values returned by os.time). In POSIX, Windows, and some other systems, this value is exactly t2-t1.",
+            "type": "function",
+            "args": [
+              {
+                "name": "t2"
+              },
+              {
+                "name": "t1"
+              }
+            ],
+            "argsDisplay": "t2, t1"
+          },
+          "execute": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-os.execute",
+            "description": "This function is equivalent to the ISO C function system. It passes command to be executed by an operating system shell. Its first result is true if the command terminated successfully, or fail otherwise. After this first result the function returns a string plus a number, as follows:",
+            "type": "function",
+            "args": [],
+            "argsDisplay": "[command]"
+          },
+          "exit": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-os.exit",
+            "description": "Calls the ISO C function exit to terminate the host program. If code is true, the returned status is EXIT_SUCCESS; if code is false, the returned status is EXIT_FAILURE; if code is a number, the returned status is this number. The default value for code is true.",
+            "type": "function",
+            "args": [],
+            "argsDisplay": "[code [, close]]"
+          },
+          "getenv": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-os.getenv",
+            "description": "Returns the value of the process environment variable varname or fail if the variable is not defined.",
+            "type": "function",
+            "args": [
+              {
+                "name": "varname"
+              }
+            ],
+            "argsDisplay": "varname"
+          },
+          "remove": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-os.remove",
+            "description": "Deletes the file (or empty directory, on POSIX systems) with the given name. If this function fails, it returns fail plus a string describing the error and the error code. Otherwise, it returns true.",
+            "type": "function",
+            "args": [
+              {
+                "name": "filename"
+              }
+            ],
+            "argsDisplay": "filename"
+          },
+          "rename": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-os.rename",
+            "description": "Renames the file or directory named oldname to newname. If this function fails, it returns fail, plus a string describing the error and the error code. Otherwise, it returns true.",
+            "type": "function",
+            "args": [
+              {
+                "name": "oldname"
+              },
+              {
+                "name": "newname"
+              }
+            ],
+            "argsDisplay": "oldname, newname"
+          },
+          "setlocale": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-os.setlocale",
+            "description": "Sets the current locale of the program. locale is a system-dependent string specifying a locale; category is an optional string describing which category to change: \"all\", \"collate\", \"ctype\", \"monetary\", \"numeric\", or \"time\"; the default category is \"all\". The function returns the name of the new locale, or fail if the request cannot be honored.",
+            "type": "function",
+            "args": [
+              {
+                "name": "locale"
+              }
+            ],
+            "argsDisplay": "locale [, category]"
+          },
+          "time": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-os.time",
+            "description": "Returns the current time when called without arguments, or a time representing the local date and time specified by the given table. This table must have fields year, month, and day, and may have fields hour (default is 12), min (default is 0), sec (default is 0), and isdst (default is nil). Other fields are ignored. For a description of these fields, see the os.date function.",
+            "type": "function",
+            "args": [],
+            "argsDisplay": "[table]"
+          },
+          "tmpname": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-os.tmpname",
+            "description": "Returns a string with a file name that can be used for a temporary file. The file must be explicitly opened before its use and explicitly removed when no longer needed.",
+            "type": "function",
+            "args": [],
+            "argsDisplay": ""
+          }
+        }
+      },
+      "package": {
+        "link": "https://www.lua.org/manual/5.4/manual.html#6.3",
+        "description": "The package library provides basic facilities for loading modules in Lua. It exports one function directly in the global environment: require. Everything else is exported in the table package.",
+        "type": "table",
+        "fields": {
+          "config": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-package.config",
+            "description": "A string describing some compile-time configurations for packages. This string is a sequence of lines:",
+            "type": "unknown"
+          },
+          "cpath": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-package.cpath",
+            "description": "A string with the path used by require to search for a C loader.",
+            "type": "unknown"
+          },
+          "loaded": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-package.loaded",
+            "description": "A table used by require to control which modules are already loaded. When you require a module modname and package.loaded[modname] is not false, require simply returns the value stored there.",
+            "type": "unknown"
+          },
+          "loadlib": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-package.loadlib",
+            "description": "Dynamically links the host program with the C library libname.",
+            "type": "function",
+            "args": [
+              {
+                "name": "libname"
+              },
+              {
+                "name": "funcname"
+              }
+            ],
+            "argsDisplay": "libname, funcname"
+          },
+          "path": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-package.path",
+            "description": "A string with the path used by require to search for a Lua loader.",
+            "type": "unknown"
+          },
+          "preload": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-package.preload",
+            "description": "A table to store loaders for specific modules (see require).",
+            "type": "unknown"
+          },
+          "searchers": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-package.searchers",
+            "description": "A table used by require to control how to find modules.",
+            "type": "unknown"
+          },
+          "searchpath": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-package.searchpath",
+            "description": "Searches for the given name in the given path.",
+            "type": "function",
+            "args": [
+              {
+                "name": "name"
+              },
+              {
+                "name": "path"
+              }
+            ],
+            "argsDisplay": "name, path [, sep [, rep]]"
+          }
+        }
+      },
+      "string": {
+        "link": "https://www.lua.org/manual/5.4/manual.html#6.4",
+        "description": "This library provides generic functions for string manipulation, such as finding and extracting substrings, and pattern matching. When indexing a string in Lua, the first character is at position 1 (not at 0, as in C). Indices are allowed to be negative and are interpreted as indexing backwards, from the end of the string. Thus, the last character is at position -1, and so on.",
+        "type": "table",
+        "fields": {
+          "byte": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-string.byte",
+            "description": "Returns the internal numeric codes of the characters s[i], s[i+1], ..., s[j]. The default value for i is 1; the default value for j is i. These indices are corrected following the same rules of function string.sub.",
+            "type": "function",
+            "args": [
+              {
+                "name": "s"
+              }
+            ],
+            "argsDisplay": "s [, i [, j]]"
+          },
+          "char": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-string.char",
+            "description": "Receives zero or more integers. Returns a string with length equal to the number of arguments, in which each character has the internal numeric code equal to its corresponding argument.",
+            "type": "function",
+            "args": [],
+            "argsDisplay": "···"
+          },
+          "dump": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-string.dump",
+            "description": "Returns a string containing a binary representation (a binary chunk) of the given function, so that a later load on this string returns a copy of the function (but with new upvalues). If strip is a true value, the binary representation may not include all debug information about the function, to save space.",
+            "type": "function",
+            "args": [
+              {
+                "name": "function"
+              }
+            ],
+            "argsDisplay": "function [, strip]"
+          },
+          "find": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-string.find",
+            "description": "Looks for the first match of pattern (see §6.4.1) in the string s. If it finds a match, then find returns the indices of s where this occurrence starts and ends; otherwise, it returns fail. A third, optional numeric argument init specifies where to start the search; its default value is 1 and can be negative. A value of true as a fourth, optional argument plain turns off the pattern matching facilities, so the function does a plain \"find substring\" operation, with no characters in pattern being considered magic.",
+            "type": "function",
+            "args": [
+              {
+                "name": "s"
+              },
+              {
+                "name": "pattern"
+              }
+            ],
+            "argsDisplay": "s, pattern [, init [, plain]]"
+          },
+          "format": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-string.format",
+            "description": "Returns a formatted version of its variable number of arguments following the description given in its first argument, which must be a string. The format string follows the same rules as the ISO C function sprintf. The only differences are that the conversion specifiers and modifiers *, h, L, l, and n are not supported and that there is an extra specifier, q.",
+            "type": "function",
+            "args": [
+              {
+                "name": "formatstring"
+              }
+            ],
+            "argsDisplay": "formatstring, ···"
+          },
+          "gmatch": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-string.gmatch",
+            "description": "Returns an iterator function that, each time it is called, returns the next captures from pattern (see §6.4.1) over the string s. If pattern specifies no captures, then the whole match is produced in each call. A third, optional numeric argument init specifies where to start the search; its default value is 1 and can be negative.",
+            "type": "function",
+            "args": [
+              {
+                "name": "s"
+              },
+              {
+                "name": "pattern"
+              }
+            ],
+            "argsDisplay": "s, pattern [, init]"
+          },
+          "gsub": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-string.gsub",
+            "description": "Returns a copy of s in which all (or the first n, if given) occurrences of the pattern (see §6.4.1) have been replaced by a replacement string specified by repl, which can be a string, a table, or a function. gsub also returns, as its second value, the total number of matches that occurred. The name gsub comes from Global SUBstitution.",
+            "type": "function",
+            "args": [
+              {
+                "name": "s"
+              },
+              {
+                "name": "pattern"
+              },
+              {
+                "name": "repl"
+              }
+            ],
+            "argsDisplay": "s, pattern, repl [, n]"
+          },
+          "len": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-string.len",
+            "description": "Receives a string and returns its length. The empty string \"\" has length 0. Embedded zeros are counted, so \"a\\000bc\\000\" has length 5.",
+            "type": "function",
+            "args": [
+              {
+                "name": "s"
+              }
+            ],
+            "argsDisplay": "s"
+          },
+          "lower": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-string.lower",
+            "description": "Receives a string and returns a copy of this string with all uppercase letters changed to lowercase. All other characters are left unchanged. The definition of what an uppercase letter is depends on the current locale.",
+            "type": "function",
+            "args": [
+              {
+                "name": "s"
+              }
+            ],
+            "argsDisplay": "s"
+          },
+          "match": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-string.match",
+            "description": "Looks for the first match of the pattern (see §6.4.1) in the string s. If it finds one, then match returns the captures from the pattern; otherwise it returns fail. If pattern specifies no captures, then the whole match is returned. A third, optional numeric argument init specifies where to start the search; its default value is 1 and can be negative.",
+            "type": "function",
+            "args": [
+              {
+                "name": "s"
+              },
+              {
+                "name": "pattern"
+              }
+            ],
+            "argsDisplay": "s, pattern [, init]"
+          },
+          "pack": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-string.pack",
+            "description": "Returns a binary string containing the values v1, v2, etc. serialized in binary form (packed) according to the format string fmt (see §6.4.2).",
+            "type": "function",
+            "args": [
+              {
+                "name": "fmt"
+              },
+              {
+                "name": "v1"
+              },
+              {
+                "name": "v2"
+              }
+            ],
+            "argsDisplay": "fmt, v1, v2, ···"
+          },
+          "packsize": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-string.packsize",
+            "description": "Returns the size of a string resulting from string.pack with the given format. The format string cannot have the variable-length options 's' or 'z' (see §6.4.2).",
+            "type": "function",
+            "args": [
+              {
+                "name": "fmt"
+              }
+            ],
+            "argsDisplay": "fmt"
+          },
+          "rep": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-string.rep",
+            "description": "Returns a string that is the concatenation of n copies of the string s separated by the string sep. The default value for sep is the empty string (that is, no separator). Returns the empty string if n is not positive.",
+            "type": "function",
+            "args": [
+              {
+                "name": "s"
+              },
+              {
+                "name": "n"
+              }
+            ],
+            "argsDisplay": "s, n [, sep]"
+          },
+          "reverse": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-string.reverse",
+            "description": "Returns a string that is the string s reversed.",
+            "type": "function",
+            "args": [
+              {
+                "name": "s"
+              }
+            ],
+            "argsDisplay": "s"
+          },
+          "sub": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-string.sub",
+            "description": "Returns the substring of s that starts at i and continues until j; i and j can be negative. If j is absent, then it is assumed to be equal to -1 (which is the same as the string length). In particular, the call string.sub(s,1,j) returns a prefix of s with length j, and string.sub(s, -i) (for a positive i) returns a suffix of s with length i.",
+            "type": "function",
+            "args": [
+              {
+                "name": "s"
+              },
+              {
+                "name": "i"
+              }
+            ],
+            "argsDisplay": "s, i [, j]"
+          },
+          "unpack": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-string.unpack",
+            "description": "Returns the values packed in string s (see string.pack) according to the format string fmt (see §6.4.2). An optional pos marks where to start reading in s (default is 1). After the read values, this function also returns the index of the first unread byte in s.",
+            "type": "function",
+            "args": [
+              {
+                "name": "fmt"
+              },
+              {
+                "name": "s"
+              }
+            ],
+            "argsDisplay": "fmt, s [, pos]"
+          },
+          "upper": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-string.upper",
+            "description": "Receives a string and returns a copy of this string with all lowercase letters changed to uppercase. All other characters are left unchanged. The definition of what a lowercase letter is depends on the current locale.",
+            "type": "function",
+            "args": [
+              {
+                "name": "s"
+              }
+            ],
+            "argsDisplay": "s"
+          }
+        }
+      },
+      "table": {
+        "link": "https://www.lua.org/manual/5.4/manual.html#6.6",
+        "description": "This library provides generic functions for table manipulation. It provides all its functions inside the table table.",
+        "type": "table",
+        "fields": {
+          "concat": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-table.concat",
+            "description": "Given a list where all elements are strings or numbers, returns the string list[i]..sep..list[i+1] ··· sep..list[j]. The default value for sep is the empty string, the default for i is 1, and the default for j is #list. If i is greater than j, returns the empty string.",
+            "type": "function",
+            "args": [
+              {
+                "name": "list"
+              }
+            ],
+            "argsDisplay": "list [, sep [, i [, j]]]"
+          },
+          "insert": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-table.insert",
+            "description": "Inserts element value at position pos in list, shifting up the elements list[pos], list[pos+1], ···, list[#list]. The default value for pos is #list+1, so that a call table.insert(t,x) inserts x at the end of the list t.",
+            "type": "function",
+            "args": [
+              {
+                "name": "list"
+              }
+            ],
+            "argsDisplay": "list, [pos,] value"
+          },
+          "move": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-table.move",
+            "description": "Moves elements from the table a1 to the table a2, performing the equivalent to the following multiple assignment: a2[t],··· = a1[f],···,a1[e]. The default for a2 is a1. The destination range can overlap with the source range. The number of elements to be moved must fit in a Lua integer.",
+            "type": "function",
+            "args": [
+              {
+                "name": "a1"
+              },
+              {
+                "name": "f"
+              },
+              {
+                "name": "e"
+              },
+              {
+                "name": "t"
+              }
+            ],
+            "argsDisplay": "a1, f, e, t [,a2]"
+          },
+          "pack": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-table.pack",
+            "description": "Returns a new table with all arguments stored into keys 1, 2, etc. and with a field \"n\" with the total number of arguments. Note that the resulting table may not be a sequence, if some arguments are nil.",
+            "type": "function",
+            "args": [],
+            "argsDisplay": "···"
+          },
+          "remove": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-table.remove",
+            "description": "Removes from list the element at position pos, returning the value of the removed element. When pos is an integer between 1 and #list, it shifts down the elements list[pos+1], list[pos+2], ···, list[#list] and erases element list[#list]; The index pos can also be 0 when #list is 0, or #list + 1.",
+            "type": "function",
+            "args": [
+              {
+                "name": "list"
+              }
+            ],
+            "argsDisplay": "list [, pos]"
+          },
+          "sort": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-table.sort",
+            "description": "Sorts the list elements in a given order, in-place, from list[1] to list[#list]. If comp is given, then it must be a function that receives two list elements and returns true when the first element must come before the second in the final order (so that, after the sort, i < j implies not comp(list[j],list[i])). If comp is not given, then the standard Lua operator < is used instead.",
+            "type": "function",
+            "args": [
+              {
+                "name": "list"
+              }
+            ],
+            "argsDisplay": "list [, comp]"
+          },
+          "unpack": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-table.unpack",
+            "description": "Returns the elements from the given list. This function is equivalent to",
+            "type": "function",
+            "args": [
+              {
+                "name": "list"
+              }
+            ],
+            "argsDisplay": "list [, i [, j]]"
+          }
+        }
+      },
+      "utf8": {
+        "link": "https://www.lua.org/manual/5.4/manual.html#6.5",
+        "description": "This library provides basic support for UTF-8 encoding. It provides all its functions inside the table utf8. This library does not provide any support for Unicode other than the handling of the encoding. Any operation that needs the meaning of a character, such as character classification, is outside its scope.",
+        "type": "table",
+        "fields": {
+          "char": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-utf8.char",
+            "description": "Receives zero or more integers, converts each one to its corresponding UTF-8 byte sequence and returns a string with the concatenation of all these sequences.",
+            "type": "function",
+            "args": [],
+            "argsDisplay": "···"
+          },
+          "charpattern": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-utf8.charpattern",
+            "description": "The pattern (a string, not a function) \"[\\0-\\x7F\\xC2-\\xFD][\\x80-\\xBF]*\" (see §6.4.1), which matches exactly one UTF-8 byte sequence, assuming that the subject is a valid UTF-8 string.",
+            "type": "unknown"
+          },
+          "codepoint": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-utf8.codepoint",
+            "description": "Returns the code points (as integers) from all characters in s that start between byte position i and j (both included). The default for i is 1 and for j is i. It raises an error if it meets any invalid byte sequence.",
+            "type": "function",
+            "args": [
+              {
+                "name": "s"
+              }
+            ],
+            "argsDisplay": "s [, i [, j [, lax]]]"
+          },
+          "codes": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-utf8.codes",
+            "description": "Returns values so that the construction",
+            "type": "function",
+            "args": [
+              {
+                "name": "s"
+              }
+            ],
+            "argsDisplay": "s [, lax]"
+          },
+          "len": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-utf8.len",
+            "description": "Returns the number of UTF-8 characters in string s that start between positions i and j (both inclusive). The default for i is 1 and for j is -1. If it finds any invalid byte sequence, returns fail plus the position of the first invalid byte.",
+            "type": "function",
+            "args": [
+              {
+                "name": "s"
+              }
+            ],
+            "argsDisplay": "s [, i [, j [, lax]]]"
+          },
+          "offset": {
+            "link": "https://www.lua.org/manual/5.4/manual.html#pdf-utf8.offset",
+            "description": "Returns the position (in bytes) where the encoding of the n-th character of s (counting from position i) starts. A negative n gets characters before position i. The default for i is 1 when n is non-negative and #s + 1 otherwise, so that utf8.offset(s, -n) gets the offset of the n-th character from the end of the string. If the specified character is neither in the subject nor right after its end, the function returns fail.",
+            "type": "function",
+            "args": [
+              {
+                "name": "s"
+              },
+              {
+                "name": "n"
+              }
+            ],
+            "argsDisplay": "s, n [, i]"
+          }
+        }
+      }
+    }
+  },
+  "namedTypes": {
+    "file": {
+      "type": "table",
+      "fields": {},
+      "metatable": {
+        "type": "table",
+        "fields": {
+          "__index": {
+            "type": "table",
+            "fields": {
+              "close": {
+                "link": "https://www.lua.org/manual/5.4/manual.html#pdf-file:close",
+                "description": "Closes file. Note that files are automatically closed when their handles are garbage collected, but that takes an unpredictable amount of time to happen.",
+                "type": "function",
+                "args": [
+                  {
+                    "name": "self"
+                  }
+                ],
+                "argsDisplay": "self",
+                "argsDisplayOmitSelf": ""
+              },
+              "flush": {
+                "link": "https://www.lua.org/manual/5.4/manual.html#pdf-file:flush",
+                "description": "Saves any written data to file.",
+                "type": "function",
+                "args": [
+                  {
+                    "name": "self"
+                  }
+                ],
+                "argsDisplay": "self",
+                "argsDisplayOmitSelf": ""
+              },
+              "lines": {
+                "link": "https://www.lua.org/manual/5.4/manual.html#pdf-file:lines",
+                "description": "Returns an iterator function that, each time it is called, reads the file according to the given formats. When no format is given, uses \"l\" as a default. As an example, the construction",
+                "type": "function",
+                "args": [
+                  {
+                    "name": "self"
+                  }
+                ],
+                "argsDisplay": "self, ···",
+                "argsDisplayOmitSelf": "···"
+              },
+              "read": {
+                "link": "https://www.lua.org/manual/5.4/manual.html#pdf-file:read",
+                "description": "Reads the file file, according to the given formats, which specify what to read. For each format, the function returns a string or a number with the characters read, or fail if it cannot read data with the specified format. (In this latter case, the function does not read subsequent formats.) When called without arguments, it uses a default format that reads the next line (see below).",
+                "type": "function",
+                "args": [
+                  {
+                    "name": "self"
+                  }
+                ],
+                "argsDisplay": "self, ···",
+                "argsDisplayOmitSelf": "···"
+              },
+              "seek": {
+                "link": "https://www.lua.org/manual/5.4/manual.html#pdf-file:seek",
+                "description": "Sets and gets the file position, measured from the beginning of the file, to the position given by offset plus a base specified by the string whence, as follows:",
+                "type": "function",
+                "args": [
+                  {
+                    "name": "self"
+                  }
+                ],
+                "argsDisplay": "self, [whence [, offset]]",
+                "argsDisplayOmitSelf": "[whence [, offset]]"
+              },
+              "setvbuf": {
+                "link": "https://www.lua.org/manual/5.4/manual.html#pdf-file:setvbuf",
+                "description": "Sets the buffering mode for a file. There are three available modes:",
+                "type": "function",
+                "args": [
+                  {
+                    "name": "self"
+                  },
+                  {
+                    "name": "mode"
+                  }
+                ],
+                "argsDisplay": "self, mode [, size]",
+                "argsDisplayOmitSelf": "mode [, size]"
+              },
+              "write": {
+                "link": "https://www.lua.org/manual/5.4/manual.html#pdf-file:write",
+                "description": "Writes the value of each of its arguments to file. The arguments must be strings or numbers.",
+                "type": "function",
+                "args": [
+                  {
+                    "name": "self"
+                  }
+                ],
+                "argsDisplay": "self, ···",
+                "argsDisplayOmitSelf": "···"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
         "5.1",
         "5.2",
         "5.3",
+        "5.4",
         "luajit-2.0"
       ],
       "title": "Default Lua version",

--- a/scraper/index.js
+++ b/scraper/index.js
@@ -160,7 +160,7 @@ function processSymbols () {
   options.global.fields.math.fields.pi.type = 'number'
 
   const filePath = path.join(__dirname, '..', 'lib', 'stdlib', `${luaVersion.replace(/\./g, '_')}.json`)
-  fs.writeFile(filePath, JSON.stringify(options, null, 2))
+  fs.writeFile(filePath, JSON.stringify(options, null, 2), () => {})
 }
 
 let parsingFunctions = false


### PR DESCRIPTION
This does not extend to the parser; which will use lua 5.3 rules for the time being.
for the most part this CL was created by searching for "5.2" in the code and updating those places, if there's anything I may have missed feel free to let me know.

WARNING: I haven't actually tested this with atom! I am instead taking the lua 5.4 json result and using it with my own extensions, which works the way you'd think it would.